### PR TITLE
Add libdedx submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libdedx"]
+	path = libdedx
+	url = https://github.com/APTG/libdedx.git


### PR DESCRIPTION
Before creating a workflow which compiles libdedx to wasm, it needs to be set as a submodule.