### PR TITLE
disable graph dragging

### DIFF
--- a/src/Components/JSRootGraph.js
+++ b/src/Components/JSRootGraph.js
@@ -12,6 +12,8 @@ function createTGraphFromDataSeries(dataSeries) {
     tgraph.fLineWidth = 2
     tgraph.fMarkerSize = 1
     //tgraph.fMarkerStyle = 8
+    tgraph.InvertBit(JSROOT.BIT(18)) // https://github.com/root-project/root/blob/v6-25-01/hist/hist/inc/TGraph.h#L72
+    
     return tgraph
 }
 

--- a/src/Components/JSRootGraph.js
+++ b/src/Components/JSRootGraph.js
@@ -12,7 +12,9 @@ function createTGraphFromDataSeries(dataSeries) {
     tgraph.fLineWidth = 2
     tgraph.fMarkerSize = 1
     //tgraph.fMarkerStyle = 8
-    tgraph.InvertBit(JSROOT.BIT(18)) // https://github.com/root-project/root/blob/v6-25-01/hist/hist/inc/TGraph.h#L72
+    // line below the comment sets kNotEditable bit (no 18) which disables graph dragging
+    // kNotEditable is defined in TGraph class in ROOT project: https://github.com/root-project/root/blob/v6-25-01/hist/hist/inc/TGraph.h#L72
+    tgraph.InvertBit(JSROOT.BIT(18))
     
     return tgraph
 }


### PR DESCRIPTION
Usually, graphs can be dragged, but its unintuitive. this disables the possibility to do so