### PR TITLE
update

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -32,20 +32,21 @@ jobs:
       run: ./build_wasm.sh
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wasm bin
+        name: wasm-bin
         path: |
           public/weblibdedx.wasm
         if-no-files-found: error
         retention-days: 5
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wasm js
+        name: wasm-backend
         path: |
           src/Backend/weblibdedx.js
+          src/Backend/weblibdedx.wasm
         if-no-files-found: error
         retention-days: 5
 
@@ -56,8 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [22.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -67,14 +67,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: wasm bin
+        name: wasm-bin
         path: public
    
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: wasm js
+        name: wasm-backend
         path: src/Backend
 
     - name: Test downloaded file structure
@@ -109,14 +109,14 @@ jobs:
           # Private SSH key to register in the SSH agent
           ssh-private-key: ${{ secrets.WEBDEV }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wasm bin
+          name: wasm-bin
           path: public
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wasm js
+          name: wasm-backend
           path: src/Backend
 
       - name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/Components/Footer/deploy.json
 src/Backend/weblibdedx.js
 .gitignore
 public/weblibdedx.wasm
+src/Backend/weblibdedx.wasm
 .vscode/settings.json
 public/weblibdedx.data
 .env

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,10 +1,5 @@
 PROJECT_NAME=weblibdedx
-# Fixed path doesn't try to read the process.env.PUBLIC_URL variable
-# It places the whole literal "${process.env.PUBLIC_URL}" inside the .js code 
-# to later be interpreted in react build process
-FIXED_PATH="\${process.env.PUBLIC_URL}\/$PROJECT_NAME.wasm"
 JS=./src/Backend/$PROJECT_NAME.js
-WASM_LOOKUP="wasmBinaryFile = locateFile"
 
 cd ./libdedx
 
@@ -50,7 +45,7 @@ FUNCTIONS+=']'
 # but the size of our dataset isn't staggering 
 # so it doesn't cause much of a slowdown. 
 # In short it's more comfortable and reliable when using the generated file as a react module.
-emcc libdedx.a -o $PROJECT_NAME.js -s EXPORTED_FUNCTIONS="$FUNCTIONS" -s ENVIRONMENT='web' -s USE_ES6_IMPORT_META=0 -s EXPORT_ES6=1 -s MODULARIZE=1 -s WASM=1 -s EXPORTED_RUNTIME_METHODS=["ccall","cwrap","UTF8ToString"] -s ALLOW_MEMORY_GROWTH=1 --embed-file ../../libdedx/data@data/
+emcc libdedx.a -o $PROJECT_NAME.js -s EXPORTED_FUNCTIONS="$FUNCTIONS" -s ENVIRONMENT='web' -s EXPORT_ES6=1 -s MODULARIZE=1 -s WASM=1 -s EXPORTED_RUNTIME_METHODS=["ccall","cwrap","UTF8ToString"] -s ALLOW_MEMORY_GROWTH=1 --embed-file ../../libdedx/data@data/
 
 ls -al
 
@@ -58,10 +53,9 @@ cd ../../..
 
 cp ./libdedx/build/libdedx/$PROJECT_NAME.js ./src/Backend
 cp ./libdedx/build/libdedx/$PROJECT_NAME.wasm ./public
+cp ./libdedx/build/libdedx/$PROJECT_NAME.wasm ./src/Backend
 
 sed -i '1s;^;\/* eslint-disable *\/\n;' ${JS}
-sed -i "s/'$PROJECT_NAME.wasm'/\`$FIXED_PATH\`/g" ${JS}
-sed -i "s/$WASM_LOOKUP/\/\/$WASM_LOOKUP/" ${JS}
 
 #cleanup
 rm -r libdedx/build


### PR DESCRIPTION
This pull request updates the build and deployment workflow for the WASM backend and simplifies the WASM build script. The main changes involve upgrading GitHub Actions dependencies, updating artifact naming and handling, restricting Node.js versions, and removing unused code from the build script.

**CI/CD Workflow Updates:**

* Upgraded all uses of `actions/upload-artifact` and `actions/download-artifact` from version 3 to version 4, ensuring compatibility with the latest GitHub Actions features and security updates. [[1]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L35-R49) [[2]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L70-R77) [[3]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L112-R119)
* Standardized artifact names from `wasm bin` and `wasm js` to `wasm-bin` and `wasm-backend`, and updated the paths to ensure both `.js` and `.wasm` files are included in the correct artifacts. [[1]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L35-R49) [[2]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L70-R77) [[3]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L112-R119)
* Updated the Node.js version matrix in the workflow to use only Node.js 22.x, dropping support for older versions.

**Build Script Simplification:**

* Removed unused variables and code from `build_wasm.sh` related to custom WASM path handling and unnecessary Emscripten flags, streamlining the build process. [[1]](diffhunk://#diff-42d3edf3b2160a25eda2b0bd55721ff4e22681e93f887dc98ff8fba3e7caf9ccL2-L7) [[2]](diffhunk://#diff-42d3edf3b2160a25eda2b0bd55721ff4e22681e93f887dc98ff8fba3e7caf9ccL53-L64)
* Now copies the generated `.wasm` file to both `public` and `src/Backend` directories to match the updated artifact handling in the workflow.