### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   wasm-verify:
     name: WASM Build + Contract Verification


### PR DESCRIPTION
Potential fix for [https://github.com/APTG/dedx_web/security/code-scanning/4](https://github.com/APTG/dedx_web/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token scopes by default.  
For this workflow, the minimal safe baseline is:

- `contents: read` (needed for checkout/repo reads)
- `actions: read` (supports artifact interactions and workflow action metadata reads in a constrained way)

Place this block after the `on:` section and before `jobs:` so all three jobs (`wasm-verify`, `unit-tests`, `e2e-tests`) inherit it without changing existing behavior.

No imports, methods, or extra definitions are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
