### PR TITLE
feat(picker): advanced search operators for picker tabs (#609)

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -17,6 +17,9 @@ Use one bullet per session (newest first):
 
 ## Entries (newest first)
 
+- 2026-05-26 — **Stage 5 — entity-selection**: Advanced search operators for picker tabs (#609): `z>N`/`z>=N`/`z<N`/`z<=N` for particles, `ρ>N`/`ρ>=N`/`ρ<N`/`ρ<=N`/`ρ=N` (+ `rho` alias) for materials, `tag=fn`/`tag=tab`/`tag=data`/`tag=ext`/`v=<string>` for programs. 13 new unit tests. Spec updated. (Claude Sonnet 4.6 via Claude Code)
+  - **Log:** [log](docs/ai-logs/2026-05-26-issue-609-advanced-search-syntax.md)
+
 - 2026-05-26 — **Stage 5 — entity-selection**: Decompose `particle-tab.svelte` into focused `particle-list-view` and `particle-grid-view` sub-components (#615) (Claude Opus 4.7 via Claude Code)
   - **Log:** [log](docs/ai-logs/2026-05-26-issue-615-particle-tab-decompose.md)
 

--- a/docs/04-feature-specs/entity-selection.md
+++ b/docs/04-feature-specs/entity-selection.md
@@ -432,7 +432,13 @@ See the "Adaptive Picker Kit" section for full details.
 External-only particles use the `🔗 <name>` prefix and sort into the flat
 list by Z; they do NOT form an "External" group.
 
-Search supports name, symbol, alias, bare Z, and `z=N` operator syntax.
+Search supports name, symbol, alias, bare Z, and advanced operator syntax:
+
+| Syntax         | Meaning                                 |
+| -------------- | --------------------------------------- |
+| `z=N`          | Exact atomic-number match               |
+| `z>N` / `z>=N` | Atomic number greater than / at least N |
+| `z<N` / `z<=N` | Atomic number less than / at most N     |
 
 ### Material tab
 
@@ -452,6 +458,17 @@ Custom sub-tab (Advanced only): lists user-defined compounds with per-row
 edit action and a clearly visible `+ New custom material` pill button that
 opens the Custom Compound Editor modal.
 
+Search supports name, ID, and advanced density operator syntax:
+
+| Syntax         | Meaning                                          |
+| -------------- | ------------------------------------------------ |
+| `ρ>N` / `ρ>=N` | Density greater than / at least N g/cm³          |
+| `ρ<N` / `ρ<=N` | Density less than / at most N g/cm³              |
+| `ρ=N`          | Density approximately equal to N g/cm³ (±0.0001) |
+| `rho>N` (etc.) | ASCII alias for `ρ` — same operators apply       |
+
+External-only materials without a declared density are excluded by any `ρ` operator.
+
 ### Program tab
 
 No section headers — each row carries its own inline tag:
@@ -464,6 +481,17 @@ No section headers — each row carries its own inline tag:
 
 Tags render as small pill badges at the right of each row. A legend strip
 below the list seeds the mapping for first-time users.
+
+Search supports name, version substring, and advanced operator syntax:
+
+| Syntax                 | Meaning                                              |
+| ---------------------- | ---------------------------------------------------- |
+| `tag=fn`               | Show only analytical-model programs (FN badge)       |
+| `tag=tab` / `tag=data` | Show only tabulated-data programs (TAB/DATA badge)   |
+| `tag=ext`              | Show only external programs (EXT badge)              |
+| `v=<string>`           | Show only programs whose version contains `<string>` |
+
+Tag matching is case-insensitive. `tag=data` is an alias for `tag=tab`.
 
 Auto-select hero card sits at the top of the list, larger and visually
 prominent, showing the resolved program (`✦ Auto-select → ICRU 49 [DATA]`).
@@ -524,7 +552,7 @@ array and seeds a fresh selection. No sidebar, no full-panel mode.
 - [ ] Electron (id 1001) does not appear in any list, periodic-grid,
       or search result.
 - [ ] Advanced mode renders the periodic-grid scan view.
-- [ ] Filter syntax `z=N` and `z>=N` work in Advanced.
+- [x] Filter syntax `z=N`, `z>N`, `z>=N`, `z<N`, `z<=N` work (#609).
 
 #### Material
 
@@ -533,11 +561,13 @@ array and seeds a fresh selection. No sidebar, no full-panel mode.
 - [ ] Density is rendered next to material name as `(ρ=... g/cm³)`.
 - [ ] Advanced reveals Custom column; Basic hides it.
 - [ ] `+ Add compound` and `edit` action open the modal editor.
+- [x] Density operators `ρ>N`, `ρ>=N`, `ρ<N`, `ρ<=N`, `ρ=N` (and ASCII `rho`) work (#609).
 
 #### Program
 
 - [ ] No "Tabulated / Analytical / External" section headers.
 - [ ] Each row shows a DATA / FN / EXT tag with hover tooltip.
+- [x] Search operators `tag=fn`, `tag=tab`, `tag=data`, `tag=ext`, `v=<string>` work (#609).
 - [ ] Auto-select row is visually prominent and shows resolved program.
 - [ ] Advanced mode renders the multi-program checkbox list + SELECTED
       group with drag-handle reorder.

--- a/docs/ai-logs/2026-05-26-issue-609-advanced-search-syntax.md
+++ b/docs/ai-logs/2026-05-26-issue-609-advanced-search-syntax.md
@@ -1,0 +1,59 @@
+# 2026-05-26 — Advanced Search Syntax: Operators for Picker Tabs (#609)
+
+## Session Narrative
+
+### Prompt 1: Implement issue #609 — advanced search operators for picker tabs
+
+**AI response**: Read issue #609 and explored the codebase to understand the
+current `matches` functions in all three picker tab components.
+
+Current state before this session:
+- `particle-tab.svelte`: supports substring + `z=N` exact match only
+- `material-tab.svelte`: supports substring only (no density operators)
+- `program-tab.svelte`: supports substring against name + version only
+
+Implemented the following enhancements:
+
+1. **`particle-tab.svelte`** — extended `matches` to support Z inequality
+   operators (`z>N`, `z>=N`, `z<N`, `z<=N`) using `atomicNumber(p)` so
+   both built-in and external particles are handled uniformly. The existing
+   `z=N` exact match was also switched to use `atomicNumber(p)` instead of
+   the raw `p.id` reference (same behaviour, more consistent).
+
+2. **`material-tab.svelte`** — added `ρ` (and ASCII alias `rho`) density
+   operators: `ρ>N`, `ρ>=N`, `ρ<N`, `ρ<=N`, `ρ=N`. External-only materials
+   without a declared density return `false` for any `ρ` operator.
+
+3. **`program-tab.svelte`** — added `tag=<kind>` and `v=<string>` operators.
+   `tag=fn` / `tag=tab` / `tag=data` / `tag=ext` filter by program kind badge
+   (case-insensitive; `data` is an alias for `tab`). `v=<string>` matches
+   programs whose version string contains the given substring.
+   The `matches` function signature was extended to include
+   `id: number | string` so `programKind()` can be called.
+
+Added 13 new unit tests in `entity-selection-tabbed.test.ts` covering all
+new operators. Updated `docs/04-feature-specs/entity-selection.md` with
+operator tables and updated acceptance criteria checkboxes.
+
+All static checks pass: format:check ✓, lint ✓, svelte-check ✓, 1469/1472
+tests pass (3 pre-existing `guard-forbidden-files` signing failures in CI).
+
+## Tasks
+
+### Implement advanced search operators for particle/material/program pickers
+
+- **Status**: completed
+- **Stage**: Stage 5 (entity-selection)
+- **Files changed**:
+  - `src/lib/components/entity-selection/particle-tab.svelte`
+  - `src/lib/components/entity-selection/material-tab.svelte`
+  - `src/lib/components/entity-selection/program-tab.svelte`
+  - `src/tests/unit/entity-selection-tabbed.test.ts`
+  - `docs/04-feature-specs/entity-selection.md`
+- **Decision**: All operators are available in both basic and advanced mode
+  (same as the existing `z=N` operator). They are power-user syntax that does
+  not interfere with ordinary substring search for casual users.
+- **Decision**: `rho` ASCII alias added for `ρ` to accommodate keyboards that
+  cannot easily type the Greek letter.
+- **Decision**: `tag=data` aliased to `tag=tab` because "DATA" is the badge
+  text shown in the UI for TAB-kind programs, so users may type what they see.

--- a/src/lib/components/entity-selection/material-tab.svelte
+++ b/src/lib/components/entity-selection/material-tab.svelte
@@ -118,7 +118,7 @@
     if (!trimmed) return true;
     const rhoOp = trimmed.match(/^(?:ρ|rho)\s*(>=|<=|>|<|=)\s*(\d+(?:\.\d+)?)$/);
     if (rhoOp) {
-      const density = isExternal(m) ? m.density : m.density;
+      const density = m.density;
       if (density === undefined) return false;
       const n = Number(rhoOp[2]);
       if (rhoOp[1] === ">=") return density >= n;

--- a/src/lib/components/entity-selection/material-tab.svelte
+++ b/src/lib/components/entity-selection/material-tab.svelte
@@ -108,9 +108,25 @@
     return `${m.id} ${m.name} ${m.rawName ?? ""}`;
   }
 
+  /**
+   * Match the query against a material's searchable text.
+   * Supports plain substring + density operators (advanced syntax):
+   *   ρ>N   ρ>=N   ρ<N   ρ<=N   ρ=N   (also accepts ASCII alias `rho`)
+   */
   function matches(m: Material, q: string): boolean {
     const trimmed = q.trim().toLowerCase();
     if (!trimmed) return true;
+    const rhoOp = trimmed.match(/^(?:ρ|rho)\s*(>=|<=|>|<|=)\s*(\d+(?:\.\d+)?)$/);
+    if (rhoOp) {
+      const density = isExternal(m) ? m.density : m.density;
+      if (density === undefined) return false;
+      const n = Number(rhoOp[2]);
+      if (rhoOp[1] === ">=") return density >= n;
+      if (rhoOp[1] === "<=") return density <= n;
+      if (rhoOp[1] === ">") return density > n;
+      if (rhoOp[1] === "<") return density < n;
+      if (rhoOp[1] === "=") return Math.abs(density - n) < 0.0001;
+    }
     return searchText(m).toLowerCase().includes(trimmed);
   }
 

--- a/src/lib/components/entity-selection/particle-tab.svelte
+++ b/src/lib/components/entity-selection/particle-tab.svelte
@@ -51,18 +51,26 @@
   }
 
   /**
-   * Match the query against a particle's searchable text. Supports plain
-   * substring + the `z=N` numeric operator (advanced syntax).
+   * Match the query against a particle's searchable text.
+   * Supports plain substring + numeric Z operators (advanced syntax):
+   *   z=N   exact atomic-number match
+   *   z>N   z>=N   z<N   z<=N   inequality range
    */
   function matches(p: Particle, q: string): boolean {
     const trimmed = q.trim().toLowerCase();
     if (!trimmed) return true;
-    const text = searchText(p).toLowerCase();
+    const z = atomicNumber(p);
     const zEq = trimmed.match(/^z\s*=\s*(\d+)$/);
-    if (zEq && !isExternal(p)) {
-      return p.id === Number(zEq[1]);
+    if (zEq) return z === Number(zEq[1]);
+    const zCmp = trimmed.match(/^z\s*(>=|<=|>|<)\s*(\d+)$/);
+    if (zCmp) {
+      const n = Number(zCmp[2]);
+      if (zCmp[1] === ">=") return z >= n;
+      if (zCmp[1] === "<=") return z <= n;
+      if (zCmp[1] === ">") return z > n;
+      if (zCmp[1] === "<") return z < n;
     }
-    return text.includes(trimmed);
+    return searchText(p).toLowerCase().includes(trimmed);
   }
 
   // spec: drop electron entirely until ESTAR ships.

--- a/src/lib/components/entity-selection/program-tab.svelte
+++ b/src/lib/components/entity-selection/program-tab.svelte
@@ -27,9 +27,26 @@
 
   let { selectionState, onSelect, query = "", showAdvancedToolbar = false }: Props = $props();
 
-  function matches(p: { name: string; version?: string | undefined }, q: string): boolean {
+  /**
+   * Match the query against a program.
+   * Supports plain substring + metadata operators (advanced syntax):
+   *   tag=FN | tag=TAB | tag=DATA | tag=EXT   filter by program kind badge
+   *   v=<string>                                filter by version substring
+   */
+  function matches(
+    p: { id: number | string; name: string; version?: string | undefined },
+    q: string,
+  ): boolean {
     const trimmed = q.trim().toLowerCase();
     if (!trimmed) return true;
+    const tagOp = trimmed.match(/^tag\s*=\s*(\w+)$/);
+    if (tagOp) {
+      const t = tagOp[1] ?? "";
+      const kind = programKind(p.id).toLowerCase();
+      return t === kind || (t === "data" && kind === "tab");
+    }
+    const vOp = trimmed.match(/^v\s*=\s*(\S+)$/);
+    if (vOp) return (p.version ?? "").toLowerCase().includes(vOp[1] ?? "");
     return (
       p.name.toLowerCase().includes(trimmed) || (p.version ?? "").toLowerCase().includes(trimmed)
     );

--- a/src/tests/unit/entity-selection-tabbed.test.ts
+++ b/src/tests/unit/entity-selection-tabbed.test.ts
@@ -5,8 +5,10 @@ import { tick } from "svelte";
 import EntitySelection from "$lib/components/entity-selection/entity-selection.svelte";
 import { createEntitySelectionState } from "$lib/state/entity-selection.svelte";
 import { buildCompatibilityMatrix } from "$lib/state/compatibility-matrix";
+import { buildExternalCompatibilityContext } from "$lib/state/external-compatibility";
 import type { ProgramEntity, ParticleEntity, MaterialEntity } from "$lib/wasm/types";
 import { isAdvancedMode } from "$lib/state/advanced-mode.svelte";
+import { makeExternalEntityStore } from "./external-entity-fixtures";
 
 class MockLibdedxService {
   getPrograms(): ProgramEntity[] {
@@ -334,6 +336,31 @@ describe("EntitySelection", () => {
     expect(screen.queryByTestId("picker-material-item-276")).not.toBeInTheDocument();
   });
 
+  test("material `ρ...` search excludes external-only materials without density", async () => {
+    const externalStore = makeExternalEntityStore();
+    externalStore.materials.push({
+      id: "nodensity",
+      name: "No Density Material",
+      index: externalStore.materials.length,
+      linearUnitsAvailable: true,
+    });
+    state.setExternalContext(
+      buildExternalCompatibilityContext([externalStore], state.allParticles, state.allMaterials),
+    );
+
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("picker-tab-material"));
+
+    const input = screen.getByTestId("picker-material-search");
+    await user.type(input, "ρ>=0");
+    expect(screen.queryByText("No Density Material")).not.toBeInTheDocument();
+
+    await user.clear(input);
+    await user.type(input, "no density material");
+    expect(screen.getByText("No Density Material")).toBeInTheDocument();
+  });
+
   test("program search supports `tag=fn` operator", async () => {
     render(EntitySelection, { props: { selectionState: state } });
     const user = userEvent.setup();
@@ -366,6 +393,20 @@ describe("EntitySelection", () => {
 
     expect(screen.getByTestId("picker-program-item-7")).toBeInTheDocument();
     expect(screen.queryByTestId("picker-program-item-101")).not.toBeInTheDocument();
+  });
+
+  test("program search supports `tag=ext` for external programs", async () => {
+    state.setExternalContext(
+      buildExternalCompatibilityContext([makeExternalEntityStore()], state.allParticles, state.allMaterials),
+    );
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-program"));
+    await user.type(screen.getByTestId("picker-program-search"), "tag=ext");
+
+    expect(screen.getByText(/SRIM GUI/)).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-program-item-7")).not.toBeInTheDocument();
   });
 
   test("program search supports `v=` version operator", async () => {

--- a/src/tests/unit/entity-selection-tabbed.test.ts
+++ b/src/tests/unit/entity-selection-tabbed.test.ts
@@ -251,6 +251,146 @@ describe("EntitySelection", () => {
     expect(screen.queryByTestId("picker-particle-item-1")).not.toBeInTheDocument();
   });
 
+  test("particle search supports `z>N` inequality operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    const input = screen.getByTestId("picker-particle-search");
+    await user.type(input, "z>2");
+
+    expect(screen.getByTestId("picker-particle-item-6")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-particle-item-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("picker-particle-item-2")).not.toBeInTheDocument();
+  });
+
+  test("particle search supports `z>=N` inequality operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    const input = screen.getByTestId("picker-particle-search");
+    await user.type(input, "z>=2");
+
+    expect(screen.getByTestId("picker-particle-item-2")).toBeInTheDocument();
+    expect(screen.getByTestId("picker-particle-item-6")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-particle-item-1")).not.toBeInTheDocument();
+  });
+
+  test("particle search supports `z<N` inequality operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    const input = screen.getByTestId("picker-particle-search");
+    await user.type(input, "z<2");
+
+    expect(screen.getByTestId("picker-particle-item-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-particle-item-2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("picker-particle-item-6")).not.toBeInTheDocument();
+  });
+
+  test("particle search supports `z<=N` inequality operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    const input = screen.getByTestId("picker-particle-search");
+    await user.type(input, "z<=2");
+
+    expect(screen.getByTestId("picker-particle-item-1")).toBeInTheDocument();
+    expect(screen.getByTestId("picker-particle-item-2")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-particle-item-6")).not.toBeInTheDocument();
+  });
+
+  test("material search supports `ρ<N` density operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-material"));
+    // Compounds sub-tab is active by default; Air (density=0.0012) and Water (density=1.0).
+    await user.type(screen.getByTestId("picker-material-search"), "ρ<0.01");
+
+    expect(screen.getByTestId("picker-material-item-267")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-material-item-276")).not.toBeInTheDocument();
+  });
+
+  test("material search supports `ρ>=N` density operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-material"));
+    // ρ>=1 should match Water (density=1.0) but not Air (density=0.0012).
+    await user.type(screen.getByTestId("picker-material-search"), "ρ>=1");
+
+    expect(screen.getByTestId("picker-material-item-276")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-material-item-267")).not.toBeInTheDocument();
+  });
+
+  test("material search supports ASCII `rho<N` alias for ρ", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-material"));
+    await user.type(screen.getByTestId("picker-material-search"), "rho<0.01");
+
+    expect(screen.getByTestId("picker-material-item-267")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-material-item-276")).not.toBeInTheDocument();
+  });
+
+  test("program search supports `tag=fn` operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-program"));
+    await user.type(screen.getByTestId("picker-program-search"), "tag=fn");
+
+    // Bethe-ext (id=101) is FN; ICRU 49 (id=7) is TAB — should be hidden.
+    expect(screen.getByTestId("picker-program-item-101")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-program-item-7")).not.toBeInTheDocument();
+  });
+
+  test("program search supports `tag=tab` operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-program"));
+    await user.type(screen.getByTestId("picker-program-search"), "tag=tab");
+
+    expect(screen.getByTestId("picker-program-item-7")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-program-item-101")).not.toBeInTheDocument();
+  });
+
+  test("program search `tag=data` is an alias for `tag=tab`", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-program"));
+    await user.type(screen.getByTestId("picker-program-search"), "tag=data");
+
+    expect(screen.getByTestId("picker-program-item-7")).toBeInTheDocument();
+    expect(screen.queryByTestId("picker-program-item-101")).not.toBeInTheDocument();
+  });
+
+  test("program search supports `v=` version operator", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-program"));
+    await user.type(screen.getByTestId("picker-program-search"), "v=1.0");
+
+    // All programs in the mock have version "1.0" — all should still be visible.
+    expect(screen.getByTestId("picker-program-item-7")).toBeInTheDocument();
+    expect(screen.getByTestId("picker-program-item-101")).toBeInTheDocument();
+  });
+
+  test("program search `v=` with no match hides all programs", async () => {
+    render(EntitySelection, { props: { selectionState: state } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("picker-tab-program"));
+    await user.type(screen.getByTestId("picker-program-search"), "v=9999");
+
+    expect(screen.queryByTestId("picker-program-item-7")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("picker-program-item-101")).not.toBeInTheDocument();
+  });
+
   test("selecting a particle when all tabs are non-empty stays put (rule A.4)", async () => {
     render(EntitySelection, { props: { selectionState: state } });
     const user = userEvent.setup();

--- a/src/tests/unit/entity-selection-tabbed.test.ts
+++ b/src/tests/unit/entity-selection-tabbed.test.ts
@@ -397,7 +397,11 @@ describe("EntitySelection", () => {
 
   test("program search supports `tag=ext` for external programs", async () => {
     state.setExternalContext(
-      buildExternalCompatibilityContext([makeExternalEntityStore()], state.allParticles, state.allMaterials),
+      buildExternalCompatibilityContext(
+        [makeExternalEntityStore()],
+        state.allParticles,
+        state.allMaterials,
+      ),
     );
     render(EntitySelection, { props: { selectionState: state } });
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary

Closes #609.

Implements advanced search operator syntax in all three picker tab `matches` functions:

- **Particle tab** — Z inequality operators: `z>N`, `z>=N`, `z<N`, `z<=N` (extends existing `z=N` exact match). Uses `atomicNumber(p)` so external particles are handled uniformly.
- **Material tab** — Density operators: `ρ>N`, `ρ>=N`, `ρ<N`, `ρ<=N`, `ρ=N`. ASCII alias `rho` supported for keyboards lacking the Greek letter. External-only materials without a declared density are excluded by any `ρ` operator.
- **Program tab** — Kind filter: `tag=fn`, `tag=tab`, `tag=data` (alias for `tab`), `tag=ext` (case-insensitive). Version filter: `v=<string>` matches programs whose version contains the substring. Extends the function signature to include `id: number | string` for `programKind()` lookup.

## Changes

| File | Change |
|---|---|
| `particle-tab.svelte` | `z>N` / `z>=N` / `z<N` / `z<=N` operators in `matches` |
| `material-tab.svelte` | `ρ` / `rho` density operators in `matches` |
| `program-tab.svelte` | `tag=` and `v=` operators in `matches`; extended type signature |
| `entity-selection-tabbed.test.ts` | 13 new unit tests |
| `docs/04-feature-specs/entity-selection.md` | Operator tables + acceptance criteria checkboxes |
| `CHANGELOG-AI.md` + session log | AI session log |

## Test plan

- [x] `pnpm run format:check` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm run check` (svelte-check + tsc) — 0 errors
- [x] `pnpm test --run` — 1469 pass, 3 pre-existing `guard-forbidden-files` signing failures unrelated to this PR
- [x] New operator tests: `z>N`, `z>=N`, `z<N`, `z<=N`, `ρ<N`, `ρ>=N`, `rho<N`, `tag=fn`, `tag=tab`, `tag=data`, `v=1.0`, `v=9999` (no match)

https://claude.ai/code/session_01S9w6U7oUx1nkXB3UWykCCW

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9w6U7oUx1nkXB3UWykCCW)_