### PR TITLE
refactor(state): decompose calculator and entity-selection monoliths (fixes #628)

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -1,5 +1,3 @@
-- **2026-05-28** (opencode / Antigravity): Decomposed `calculator.svelte.ts` and `entity-selection.svelte.ts` state monoliths into `calculator-engine.svelte.ts` and `multi-selection.svelte.ts`. Fixed related accessibility issue with export buttons. ([docs/ai-logs/2026-05-28-issue-628.md](docs/ai-logs/2026-05-28-issue-628.md))
-
 # AI Changelog
 
 > This changelog tracks all AI-assisted coding sessions on this project.
@@ -18,6 +16,9 @@ Use one bullet per session (newest first):
   - **Log:** [log](docs/ai-logs/YYYY-MM-DD-<slug>.md)
 
 ## Entries (newest first)
+
+- 2026-05-28 — **Refactoring**: Decompose `calculator.svelte.ts` and `entity-selection.svelte.ts` state monoliths into `calculator-engine.svelte.ts` and `multi-selection.svelte.ts`, with related export-button accessibility updates in `+layout.svelte`. (Antigravity via opencode)
+  - **Log:** [log](docs/ai-logs/2026-05-28-issue-628.md)
 
 - 2026-05-28 — **Testing**: Address issue #635 stale builds in Playwright. Documented the stale-build trap and the rule to keep `package.json` E2E scripts clean while relying on Playwright `webServer.command` to run `pnpm build && pnpm preview` locally (non-CI). Created a `playwright.dev.config.ts` targeting Vite dev server on port 5173 for local HMR testing. (Gemini 3.1 Pro (High) via Antigravity)
   - **Log:** [log](docs/ai-logs/2026-05-28-issue-635-stale-builds.md)

--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -1,3 +1,4 @@
+- **2026-05-28** (opencode / Antigravity): Decomposed `calculator.svelte.ts` and `entity-selection.svelte.ts` state monoliths into `calculator-engine.svelte.ts` and `multi-selection.svelte.ts`. Fixed related accessibility issue with export buttons. ([docs/ai-logs/2026-05-28-issue-628.md](docs/ai-logs/2026-05-28-issue-628.md))
 # AI Changelog
 
 > This changelog tracks all AI-assisted coding sessions on this project.

--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -1,4 +1,5 @@
 - **2026-05-28** (opencode / Antigravity): Decomposed `calculator.svelte.ts` and `entity-selection.svelte.ts` state monoliths into `calculator-engine.svelte.ts` and `multi-selection.svelte.ts`. Fixed related accessibility issue with export buttons. ([docs/ai-logs/2026-05-28-issue-628.md](docs/ai-logs/2026-05-28-issue-628.md))
+
 # AI Changelog
 
 > This changelog tracks all AI-assisted coding sessions on this project.

--- a/docs/ai-logs/2026-05-28-issue-628.md
+++ b/docs/ai-logs/2026-05-28-issue-628.md
@@ -1,0 +1,25 @@
+# AI Session Log: Issue 628 (Decompose State Monoliths)
+
+**Date**: 2026-05-28
+**Branch**: qwen/issue-628
+**Tool**: opencode
+**Model**: Antigravity
+
+## Summary
+Decomposed the monolithic Svelte 5 state files to improve maintainability, following issue #628.
+
+1. **Calculator State Decomposition**:
+   - Extracted asynchronous WASM logic and caching from `calculator.svelte.ts` into a new `calculator-engine.svelte.ts` module.
+   - Refactored `calculator.svelte.ts` to consume the engine instance, removing duplicate calculation logic.
+
+2. **Entity Selection State Decomposition**:
+   - Extracted multi-selection state (across, multiSelected arrays) and UI interaction logic from `entity-selection.svelte.ts` into a new `multi-selection.svelte.ts` module.
+   - Refactored `entity-selection.svelte.ts` to delegate multi-selection interactions to the new module.
+
+3. **Accessibility Fix**:
+   - Fixed a failing E2E accessibility test related to export buttons in `+layout.svelte`. The `!canExport.value` caused the buttons to be disabled without properly communicating to the Axe checker due to missing `aria-disabled` and text color inheritance. Added `aria-disabled={!canExport.value}` and `class="text-foreground"`.
+
+## Verification
+- Unit tests (`pnpm run test`) pass.
+- E2E tests (`pnpm exec playwright test`) pass.
+- Formatting and strict static checks (`pnpm run format`, `pnpm guard:staged`) pass.

--- a/docs/ai-logs/2026-05-28-issue-628.md
+++ b/docs/ai-logs/2026-05-28-issue-628.md
@@ -1,25 +1,28 @@
-# AI Session Log: Issue 628 (Decompose State Monoliths)
+# 2026-05-28 — Issue #628 state-monolith decomposition
 
-**Date**: 2026-05-28
-**Branch**: qwen/issue-628
-**Tool**: opencode
-**Model**: Antigravity
+## Session Narrative
 
-## Summary
-Decomposed the monolithic Svelte 5 state files to improve maintainability, following issue #628.
+### Prompt 1: Decompose calculator and entity-selection state monoliths
 
-1. **Calculator State Decomposition**:
-   - Extracted asynchronous WASM logic and caching from `calculator.svelte.ts` into a new `calculator-engine.svelte.ts` module.
-   - Refactored `calculator.svelte.ts` to consume the engine instance, removing duplicate calculation logic.
+**AI response**: Extracted calculator engine logic into `calculator-engine.svelte.ts` and multi-selection logic into `multi-selection.svelte.ts`, then updated call sites to use the extracted modules while preserving behavior.
 
-2. **Entity Selection State Decomposition**:
-   - Extracted multi-selection state (across, multiSelected arrays) and UI interaction logic from `entity-selection.svelte.ts` into a new `multi-selection.svelte.ts` module.
-   - Refactored `entity-selection.svelte.ts` to delegate multi-selection interactions to the new module.
+### Prompt 2: Address related export-button accessibility regression
 
-3. **Accessibility Fix**:
-   - Fixed a failing E2E accessibility test related to export buttons in `+layout.svelte`. The `!canExport.value` caused the buttons to be disabled without properly communicating to the Axe checker due to missing `aria-disabled` and text color inheritance. Added `aria-disabled={!canExport.value}` and `class="text-foreground"`.
+**AI response**: Updated the export controls in `src/routes/+layout.svelte` to include `aria-disabled` and inherited text color so disabled states remain clear and E2E accessibility checks pass.
 
-## Verification
-- Unit tests (`pnpm run test`) pass.
-- E2E tests (`pnpm exec playwright test`) pass.
-- Formatting and strict static checks (`pnpm run format`, `pnpm guard:staged`) pass.
+## Tasks
+
+### Issue #628 decomposition + accessibility follow-up
+
+- **Status**: completed
+- **Stage**: Refactoring
+- **Files changed**:
+  - `src/lib/state/calculator.svelte.ts`
+  - `src/lib/state/calculator-engine.svelte.ts`
+  - `src/lib/state/entity-selection.svelte.ts`
+  - `src/lib/state/multi-selection.svelte.ts`
+  - `src/routes/+layout.svelte`
+  - `CHANGELOG-AI.md`
+  - `docs/ai-logs/2026-05-28-issue-628.md`
+- **Decision**: Kept the extracted modules focused on state and calculation concerns only, with no behavior changes beyond the targeted accessibility fix.
+- **Issue**: None.

--- a/src/lib/state/calculator-engine.svelte.ts
+++ b/src/lib/state/calculator-engine.svelte.ts
@@ -11,7 +11,6 @@ import {
 import { parseExtRef } from "$lib/external-data/ids";
 import { asBuiltinMaterial } from "$lib/utils/entity-type-guards";
 import { stpMassToKevUm, csdaGcm2ToCm } from "$lib/utils/unit-conversions";
-import { resolveParticleMass } from "./calculator.svelte";
 
 export interface CalculatorEngineState {
   isCalculating: boolean;
@@ -21,6 +20,15 @@ export interface CalculatorEngineState {
   performCalculation(energies: { rowId: string; energy: number }[]): Promise<void>;
   clearResults(): void;
   resetCache(): void;
+}
+
+function resolveParticleMass(
+  particle: EntitySelectionState["selectedParticle"],
+): { massNumber: number; atomicMass: number } | null {
+  if (!particle) return null;
+  if ("massNumber" in particle)
+    return { massNumber: particle.massNumber, atomicMass: particle.atomicMass };
+  return { massNumber: particle.A, atomicMass: particle.atomicMass };
 }
 
 export function createCalculatorEngine(

--- a/src/lib/state/calculator-engine.svelte.ts
+++ b/src/lib/state/calculator-engine.svelte.ts
@@ -1,0 +1,360 @@
+import { LibdedxError } from "$lib/wasm/types";
+import type { StpUnit, LibdedxService } from "$lib/wasm/types";
+import type { EntitySelectionState } from "./entity-selection.svelte";
+import type { ExternalDataService } from "$lib/external-data/service";
+import { advancedOptions } from "./advanced-options.svelte";
+import { isAdvancedMode } from "./advanced-mode.svelte";
+import {
+  customMaterialElementsForWasm,
+  isCustomMaterial,
+} from "$lib/utils/custom-compound-material";
+import { parseExtRef } from "$lib/external-data/ids";
+import { asBuiltinMaterial } from "$lib/utils/entity-type-guards";
+import { stpMassToKevUm, csdaGcm2ToCm } from "$lib/utils/unit-conversions";
+import { resolveParticleMass } from "./calculator.svelte";
+
+export interface CalculatorEngineState {
+  isCalculating: boolean;
+  error: LibdedxError | null;
+  calculationResults: Map<string, { stoppingPower: number | null; csdaRangeCm: number | null }>;
+  outOfRangeRowIds: Set<string>;
+  performCalculation(energies: { rowId: string; energy: number }[]): Promise<void>;
+  clearResults(): void;
+  resetCache(): void;
+}
+
+export function createCalculatorEngine(
+  entitySelection: EntitySelectionState,
+  service: LibdedxService,
+  getStpDisplayUnit: () => StpUnit,
+  extService?: ExternalDataService,
+): CalculatorEngineState {
+  let isCalculating = $state(false);
+  let error = $state<LibdedxError | null>(null);
+  let calculationResults = $state<
+    Map<string, { stoppingPower: number | null; csdaRangeCm: number | null }>
+  >(new Map());
+  let outOfRangeRowIds = $state<Set<string>>(new Set());
+  const outOfRangeCache = new Set<string>();
+
+  /** Find the local ID of a particle or material within a specific external source. */
+  function resolveExtLocalId(
+    entityId: number | string,
+    label: string,
+    refMap: Map<number, string[]> | Map<number | string, string[]>,
+  ): string | null {
+    if (typeof entityId === "string" && entityId.startsWith("ext:")) {
+      const parsed = parseExtRef(entityId);
+      return parsed && parsed.label === label ? parsed.localId : null;
+    }
+    if (typeof entityId === "number") {
+      const refs = (refMap as Map<number, string[]>).get(entityId) ?? [];
+      for (const ref of refs) {
+        const p = parseExtRef(ref);
+        if (p && p.label === label) return p.localId;
+      }
+    }
+    return null;
+  }
+
+  async function performExternalCalculation(
+    energies: { rowId: string; energy: number }[],
+    programExtRef: string,
+  ): Promise<void> {
+    if (!extService) {
+      isCalculating = false;
+      return;
+    }
+
+    const parsed = parseExtRef(programExtRef);
+    if (!parsed) {
+      isCalculating = false;
+      return;
+    }
+    const { label, localId: localProgramId } = parsed;
+
+    const extCtx = entitySelection.externalContext;
+    const selectedParticle = entitySelection.selectedParticle;
+    const selectedMaterial = entitySelection.selectedMaterial;
+
+    const particleLocalId = selectedParticle
+      ? resolveExtLocalId(selectedParticle.id, label, extCtx.externalRefsForBuiltinParticle)
+      : null;
+    const materialLocalId = selectedMaterial
+      ? resolveExtLocalId(selectedMaterial.id, label, extCtx.externalRefsForBuiltinMaterial)
+      : null;
+
+    if (!particleLocalId || !materialLocalId) {
+      calculationResults = new Map();
+      isCalculating = false;
+      return;
+    }
+
+    const mass = resolveParticleMass(selectedParticle);
+    const massA = mass?.massNumber ?? 1;
+
+    const conversionDensity =
+      (isAdvancedMode.value ? advancedOptions.value.densityOverride : undefined) ??
+      selectedMaterial?.density;
+
+    const results = new Map<string, { stoppingPower: number | null; csdaRangeCm: number | null }>();
+    const externalOutOfRange = new Set<string>();
+    try {
+      for (const { rowId, energy } of energies) {
+        const totalMev = energy * massA;
+        const result = await extService.interpolateAt(
+          label,
+          localProgramId,
+          particleLocalId,
+          materialLocalId,
+          totalMev,
+        );
+        if (result.stp !== null) {
+          let stpDisplay: number | null;
+          if (getStpDisplayUnit() === "keV/µm") {
+            stpDisplay =
+              typeof conversionDensity === "number"
+                ? stpMassToKevUm(result.stp, conversionDensity)
+                : null;
+          } else {
+            stpDisplay = result.stp;
+          }
+
+          const csdaCm =
+            result.csda !== null && typeof conversionDensity === "number"
+              ? csdaGcm2ToCm(result.csda, conversionDensity)
+              : null;
+          results.set(rowId, { stoppingPower: stpDisplay, csdaRangeCm: csdaCm });
+        } else {
+          externalOutOfRange.add(rowId);
+        }
+      }
+      calculationResults = results;
+      outOfRangeRowIds = externalOutOfRange;
+    } catch (e) {
+      error = new LibdedxError(-1, e instanceof Error ? e.message : String(e));
+    } finally {
+      isCalculating = false;
+    }
+  }
+
+  async function performCalculation(energies: { rowId: string; energy: number }[]): Promise<void> {
+    if (energies.length === 0) {
+      calculationResults = new Map();
+      outOfRangeRowIds = new Set();
+      return;
+    }
+
+    isCalculating = true;
+    error = null;
+    outOfRangeRowIds = new Set();
+
+    const resolvedProgramId = entitySelection.resolvedProgramId;
+    if (typeof resolvedProgramId === "string") {
+      await performExternalCalculation(energies, resolvedProgramId);
+      return;
+    }
+    const particleId = entitySelection.selectedParticle?.id;
+    const material = entitySelection.selectedMaterial;
+    const materialId = material?.id;
+    const builtinMaterial = asBuiltinMaterial(material);
+    const customMaterial = isCustomMaterial(builtinMaterial) ? builtinMaterial : null;
+
+    if (!resolvedProgramId || !particleId || !materialId) {
+      calculationResults = new Map();
+      isCalculating = false;
+      return;
+    }
+
+    const calculationOptions =
+      isAdvancedMode.value && !customMaterial ? advancedOptions.value : undefined;
+
+    const density =
+      (isAdvancedMode.value && !customMaterial
+        ? advancedOptions.value.densityOverride
+        : undefined) ??
+      material?.density ??
+      1;
+
+    function oorCacheKey(energy: number): string {
+      return `${resolvedProgramId}:${particleId}:${materialId}:${energy}`;
+    }
+
+    const numericProgramId = resolvedProgramId as number;
+    const numericParticleId = particleId as number;
+
+    function callService(energyValues: number[]) {
+      return customMaterial
+        ? service.calculateCustomCompound({
+            programId: numericProgramId,
+            particleId: numericParticleId,
+            elements: customMaterialElementsForWasm(customMaterial!),
+            density: customMaterial!.density,
+            ...(customMaterial!.iValue !== undefined ? { iValue: customMaterial!.iValue } : {}),
+            energies: energyValues,
+          })
+        : typeof materialId === "number"
+          ? service.calculate(
+              numericProgramId,
+              numericParticleId,
+              materialId,
+              energyValues,
+              calculationOptions,
+            )
+          : null;
+    }
+
+    function processResults(
+      result: { stoppingPowers: number[]; csdaRanges: number[] },
+      items: { rowId: string; energy: number }[],
+    ): Map<string, { stoppingPower: number; csdaRangeCm: number | null }> {
+      const map = new Map<string, { stoppingPower: number; csdaRangeCm: number | null }>();
+      for (let i = 0; i < items.length; i++) {
+        const stpMass = result.stoppingPowers[i]!;
+        const csdaGcm2 = result.csdaRanges[i]!;
+        const { rowId, energy } = items[i]!;
+
+        if (
+          !Number.isFinite(stpMass) ||
+          (Math.abs(stpMass) > 0 && Math.abs(stpMass) < Number.MIN_VALUE * 1e10)
+        ) {
+          console.warn("[dedx] subnormal/invalid WASM output (stopping power)", {
+            programId: resolvedProgramId,
+            particleId,
+            materialId,
+            energyMevNucl: energy,
+            rawValue: stpMass,
+          });
+        }
+        if (
+          !Number.isFinite(csdaGcm2) ||
+          (Math.abs(csdaGcm2) > 0 && Math.abs(csdaGcm2) < Number.MIN_VALUE * 1e10)
+        ) {
+          console.warn("[dedx] subnormal/invalid WASM output (CSDA range)", {
+            programId: resolvedProgramId,
+            particleId,
+            materialId,
+            energyMevNucl: energy,
+            rawValue: csdaGcm2,
+          });
+        }
+
+        let stpDisplay: number;
+        if (getStpDisplayUnit() === "keV/µm") {
+          const converted = stpMassToKevUm(stpMass, density);
+          stpDisplay = converted ?? stpMass;
+        } else {
+          stpDisplay = stpMass;
+        }
+
+        const csdaCm = csdaGcm2ToCm(csdaGcm2, density);
+        map.set(rowId, { stoppingPower: stpDisplay, csdaRangeCm: csdaCm });
+      }
+      return map;
+    }
+
+    const cachedOorItems: { rowId: string; energy: number }[] = [];
+    let uncachedItems: { rowId: string; energy: number }[] = [];
+    for (const item of energies) {
+      if (outOfRangeCache.has(oorCacheKey(item.energy))) {
+        cachedOorItems.push(item);
+      } else {
+        uncachedItems.push(item);
+      }
+    }
+
+    const newOutOfRange = new Set<string>(cachedOorItems.map((item) => item.rowId));
+
+    if (!customMaterial && typeof materialId === "number") {
+      const minE = service.getMinEnergy(numericProgramId, numericParticleId);
+      const maxE = service.getMaxEnergy(numericProgramId, numericParticleId);
+      const inRange: { rowId: string; energy: number }[] = [];
+      for (const item of uncachedItems) {
+        if (item.energy < minE || item.energy > maxE) {
+          newOutOfRange.add(item.rowId);
+          outOfRangeCache.add(oorCacheKey(item.energy));
+        } else {
+          inRange.push(item);
+        }
+      }
+      uncachedItems = inRange;
+    }
+
+    if (uncachedItems.length === 0) {
+      calculationResults = new Map();
+      outOfRangeRowIds = newOutOfRange;
+      isCalculating = false;
+      return;
+    }
+
+    try {
+      const result = callService(uncachedItems.map((e) => e.energy));
+      if (!result) {
+        calculationResults = new Map();
+        isCalculating = false;
+        return;
+      }
+      calculationResults = processResults(result, uncachedItems);
+      outOfRangeRowIds = newOutOfRange;
+    } catch (e) {
+      if (e instanceof LibdedxError && e.code === 101) {
+        const newResults = new Map<string, { stoppingPower: number; csdaRangeCm: number | null }>();
+        let fatalError: LibdedxError | null = null;
+
+        for (const item of uncachedItems) {
+          if (fatalError) break;
+          try {
+            const result = callService([item.energy]);
+            if (result) {
+              const entry = processResults(result, [item]).get(item.rowId);
+              if (entry) newResults.set(item.rowId, entry);
+            }
+          } catch (rowErr) {
+            if (rowErr instanceof LibdedxError && rowErr.code === 101) {
+              newOutOfRange.add(item.rowId);
+              outOfRangeCache.add(oorCacheKey(item.energy));
+            } else {
+              fatalError =
+                rowErr instanceof LibdedxError
+                  ? rowErr
+                  : new LibdedxError(-1, "Calculation failed");
+            }
+          }
+        }
+
+        calculationResults = newResults;
+        outOfRangeRowIds = newOutOfRange;
+        if (fatalError) error = fatalError;
+      } else {
+        error = e instanceof LibdedxError ? e : new LibdedxError(-1, "Calculation failed");
+      }
+    } finally {
+      isCalculating = false;
+    }
+  }
+
+  return {
+    get isCalculating() {
+      return isCalculating;
+    },
+    get error() {
+      return error;
+    },
+    get calculationResults() {
+      return calculationResults;
+    },
+    get outOfRangeRowIds() {
+      return outOfRangeRowIds;
+    },
+    performCalculation,
+    clearResults() {
+      calculationResults = new Map();
+      outOfRangeRowIds = new Set();
+      isCalculating = false;
+      error = null;
+    },
+    resetCache() {
+      outOfRangeCache.clear();
+    },
+  };
+}

--- a/src/lib/state/calculator.svelte.ts
+++ b/src/lib/state/calculator.svelte.ts
@@ -6,8 +6,6 @@ import {
   getEnergyUnitCategory,
 } from "$lib/utils/energy-conversions";
 import {
-  stpMassToKevUm,
-  csdaGcm2ToCm,
   formatSigFigs,
   autoScaleLengthCm,
 } from "$lib/utils/unit-conversions";
@@ -20,15 +18,14 @@ import { debounce } from "$lib/utils/debounce";
 import { advancedOptions } from "./advanced-options.svelte";
 import { isAdvancedMode } from "./advanced-mode.svelte";
 import {
-  customMaterialElementsForWasm,
   isCustomMaterial,
 } from "$lib/utils/custom-compound-material";
-import { parseExtRef } from "$lib/external-data/ids";
 import type { ExternalDataService } from "$lib/external-data/service";
-import { asBuiltinMaterial, asBuiltinParticle } from "$lib/utils/entity-type-guards";
+import { asBuiltinParticle, asBuiltinMaterial } from "$lib/utils/entity-type-guards";
+import { createCalculatorEngine } from "./calculator-engine.svelte";
 
 /** Resolve mass fields (massNumber, atomicMass) from built-in or external-only particle. */
-function resolveParticleMass(
+export function resolveParticleMass(
   particle: ParticleEntity | ExternalOnlyParticle | null | undefined,
 ): { massNumber: number; atomicMass: number } | null {
   if (!particle) return null;
@@ -78,21 +75,11 @@ export function createCalculatorState(
   extService?: ExternalDataService,
 ): CalculatorState {
   const inputState = createEnergyInputState();
-  let isCalculating = $state(false);
-  let error = $state<LibdedxError | null>(null);
-  let calculationResults = $state<
-    Map<string, { stoppingPower: number | null; csdaRangeCm: number | null }>
-  >(new Map());
-  let outOfRangeRowIds = $state<Set<string>>(new Set());
-  // Persistent across calculations within this state instance — once an energy
-  // is identified as OOR for a given (program, particle, material) context, we
-  // skip calling WASM again. Prevents the C library from hanging on a second
-  // call with the same out-of-range energy. Key: "programId:particleId:materialId:energy".
-  const outOfRangeCache = new Set<string>();
+  const engine = createCalculatorEngine(entitySelection, service, getStpDisplayUnit, extService);
 
   const debouncedCalculate = debounce(async () => {
     const energies = getValidEnergies();
-    await performCalculation(energies);
+    await engine.performCalculation(energies);
   }, 300);
 
   function convertRowsForNewParticle(
@@ -268,9 +255,9 @@ export function createCalculatorState(
     }
 
     const rowKey = String(row.id);
-    const resultData = calculationResults.get(rowKey);
+    const resultData = engine.calculationResults.get(rowKey);
 
-    if (!resultData && outOfRangeRowIds.has(rowKey)) {
+    if (!resultData && engine.outOfRangeRowIds.has(rowKey)) {
       return {
         id: row.id,
         rawInput: row.text,
@@ -312,327 +299,6 @@ export function createCalculatorState(
     }
 
     return inputState.rows.map((row) => parseRow(row, mass.massNumber, mass.atomicMass));
-  }
-
-  /** Find the local ID of a particle or material within a specific external source. */
-  function resolveExtLocalId(
-    entityId: number | string,
-    label: string,
-    refMap: Map<number, string[]> | Map<number | string, string[]>,
-  ): string | null {
-    if (typeof entityId === "string" && entityId.startsWith("ext:")) {
-      // External-only entity: localId is already encoded in the ExtRef
-      const parsed = parseExtRef(entityId);
-      return parsed && parsed.label === label ? parsed.localId : null;
-    }
-    if (typeof entityId === "number") {
-      const refs = (refMap as Map<number, string[]>).get(entityId) ?? [];
-      for (const ref of refs) {
-        const p = parseExtRef(ref);
-        if (p && p.label === label) return p.localId;
-      }
-    }
-    return null;
-  }
-
-  /** Route calculation through ExternalDataService when an external program is selected. */
-  async function performExternalCalculation(
-    energies: { rowId: string; energy: number }[],
-    programExtRef: string,
-  ): Promise<void> {
-    if (!extService) {
-      isCalculating = false;
-      return;
-    }
-
-    const parsed = parseExtRef(programExtRef);
-    if (!parsed) {
-      isCalculating = false;
-      return;
-    }
-    const { label, localId: localProgramId } = parsed;
-
-    const extCtx = entitySelection.externalContext;
-    const selectedParticle = entitySelection.selectedParticle;
-    const selectedMaterial = entitySelection.selectedMaterial;
-
-    const particleLocalId = selectedParticle
-      ? resolveExtLocalId(selectedParticle.id, label, extCtx.externalRefsForBuiltinParticle)
-      : null;
-    const materialLocalId = selectedMaterial
-      ? resolveExtLocalId(selectedMaterial.id, label, extCtx.externalRefsForBuiltinMaterial)
-      : null;
-
-    if (!particleLocalId || !materialLocalId) {
-      calculationResults = new Map();
-      isCalculating = false;
-      return;
-    }
-
-    const mass = resolveParticleMass(selectedParticle);
-    const massA = mass?.massNumber ?? 1;
-
-    // Use the density override only in Advanced mode; Basic mode uses the
-    // selected material density when available so switching back reverts the value.
-    const conversionDensity =
-      (isAdvancedMode.value ? advancedOptions.value.densityOverride : undefined) ??
-      selectedMaterial?.density;
-
-    const results = new Map<string, { stoppingPower: number | null; csdaRangeCm: number | null }>();
-    const externalOutOfRange = new Set<string>();
-    try {
-      for (const { rowId, energy } of energies) {
-        // energy is MeV/nucl; external service expects total MeV
-        const totalMev = energy * massA;
-        const result = await extService.interpolateAt(
-          label,
-          localProgramId,
-          particleLocalId,
-          materialLocalId,
-          totalMev,
-        );
-        if (result.stp !== null) {
-          let stpDisplay: number | null;
-          if (getStpDisplayUnit() === "keV/µm") {
-            stpDisplay =
-              typeof conversionDensity === "number"
-                ? stpMassToKevUm(result.stp, conversionDensity)
-                : null;
-          } else {
-            stpDisplay = result.stp;
-          }
-
-          // result.csda is in g/cm²; convert to cm for display using material density.
-          const csdaCm =
-            result.csda !== null && typeof conversionDensity === "number"
-              ? csdaGcm2ToCm(result.csda, conversionDensity)
-              : null;
-          results.set(rowId, { stoppingPower: stpDisplay, csdaRangeCm: csdaCm });
-        } else {
-          externalOutOfRange.add(rowId);
-        }
-      }
-      calculationResults = results;
-      outOfRangeRowIds = externalOutOfRange;
-    } catch (e) {
-      error = new LibdedxError(-1, e instanceof Error ? e.message : String(e));
-    } finally {
-      isCalculating = false;
-    }
-  }
-
-  async function performCalculation(energies: { rowId: string; energy: number }[]): Promise<void> {
-    if (energies.length === 0) {
-      calculationResults = new Map();
-      outOfRangeRowIds = new Set();
-      return;
-    }
-
-    isCalculating = true;
-    error = null;
-    outOfRangeRowIds = new Set();
-
-    // Resolved outside try/catch so the per-row retry path can reuse them.
-    const resolvedProgramId = entitySelection.resolvedProgramId;
-    if (typeof resolvedProgramId === "string") {
-      await performExternalCalculation(energies, resolvedProgramId);
-      return;
-    }
-    const particleId = entitySelection.selectedParticle?.id;
-    const material = entitySelection.selectedMaterial;
-    const materialId = material?.id;
-    const builtinMaterial = asBuiltinMaterial(material);
-    const customMaterial = isCustomMaterial(builtinMaterial) ? builtinMaterial : null;
-
-    if (!resolvedProgramId || !particleId || !materialId) {
-      calculationResults = new Map();
-      isCalculating = false;
-      return;
-    }
-
-    // Only pass advanced options to WASM in Advanced mode — Basic mode uses
-    // defaults so switching back to Basic always reverts to default behaviour.
-    const calculationOptions =
-      isAdvancedMode.value && !customMaterial ? advancedOptions.value : undefined;
-
-    // Use the density override only in Advanced mode; Basic mode always uses
-    // the material's built-in density so switching back reverts the value.
-    const density =
-      (isAdvancedMode.value && !customMaterial
-        ? advancedOptions.value.densityOverride
-        : undefined) ??
-      material?.density ??
-      1;
-
-    function oorCacheKey(energy: number): string {
-      return `${resolvedProgramId}:${particleId}:${materialId}:${energy}`;
-    }
-
-    // resolvedProgramId is guaranteed numeric here (string = external, returned early above)
-    const numericProgramId = resolvedProgramId as number;
-    const numericParticleId = particleId as number;
-
-    function callService(energyValues: number[]) {
-      return customMaterial
-        ? service.calculateCustomCompound({
-            programId: numericProgramId,
-            particleId: numericParticleId,
-            elements: customMaterialElementsForWasm(customMaterial!),
-            density: customMaterial!.density,
-            ...(customMaterial!.iValue !== undefined ? { iValue: customMaterial!.iValue } : {}),
-            energies: energyValues,
-          })
-        : typeof materialId === "number"
-          ? service.calculate(
-              numericProgramId,
-              numericParticleId,
-              materialId,
-              energyValues,
-              calculationOptions,
-            )
-          : null;
-    }
-
-    function processResults(
-      result: { stoppingPowers: number[]; csdaRanges: number[] },
-      items: { rowId: string; energy: number }[],
-    ): Map<string, { stoppingPower: number; csdaRangeCm: number | null }> {
-      const map = new Map<string, { stoppingPower: number; csdaRangeCm: number | null }>();
-      for (let i = 0; i < items.length; i++) {
-        const stpMass = result.stoppingPowers[i]!;
-        const csdaGcm2 = result.csdaRanges[i]!;
-        const { rowId, energy } = items[i]!;
-
-        // Debug logging for subnormal/invalid WASM output values.
-        // This helps diagnose physics issues when WASM returns nonsensical values.
-        if (
-          !Number.isFinite(stpMass) ||
-          (Math.abs(stpMass) > 0 && Math.abs(stpMass) < Number.MIN_VALUE * 1e10)
-        ) {
-          console.warn("[dedx] subnormal/invalid WASM output (stopping power)", {
-            programId: resolvedProgramId,
-            particleId,
-            materialId,
-            energyMevNucl: energy,
-            rawValue: stpMass,
-          });
-        }
-        if (
-          !Number.isFinite(csdaGcm2) ||
-          (Math.abs(csdaGcm2) > 0 && Math.abs(csdaGcm2) < Number.MIN_VALUE * 1e10)
-        ) {
-          console.warn("[dedx] subnormal/invalid WASM output (CSDA range)", {
-            programId: resolvedProgramId,
-            particleId,
-            materialId,
-            energyMevNucl: energy,
-            rawValue: csdaGcm2,
-          });
-        }
-
-        let stpDisplay: number;
-        if (getStpDisplayUnit() === "keV/µm") {
-          const converted = stpMassToKevUm(stpMass, density);
-          stpDisplay = converted ?? stpMass;
-        } else {
-          stpDisplay = stpMass;
-        }
-
-        const csdaCm = csdaGcm2ToCm(csdaGcm2, density);
-        map.set(rowId, { stoppingPower: stpDisplay, csdaRangeCm: csdaCm });
-      }
-      return map;
-    }
-
-    // Pre-classify energies using the persistent OOR cache.
-    // Cached OOR entries are known to fail for this (program, particle, material)
-    // context — skip WASM for them to prevent redundant calls that may hang the
-    // C library on repeated out-of-range inputs.
-    const cachedOorItems: { rowId: string; energy: number }[] = [];
-    let uncachedItems: { rowId: string; energy: number }[] = [];
-    for (const item of energies) {
-      if (outOfRangeCache.has(oorCacheKey(item.energy))) {
-        cachedOorItems.push(item);
-      } else {
-        uncachedItems.push(item);
-      }
-    }
-
-    const newOutOfRange = new Set<string>(cachedOorItems.map((item) => item.rowId));
-
-    // Range pre-check: classify items outside the tabulated energy limits as OOR
-    // without calling WASM. Some programs (e.g. ICRU 49) hang in _dedx_get_stp_table
-    // on out-of-range energies rather than returning error code 101.
-    if (!customMaterial && typeof materialId === "number") {
-      const minE = service.getMinEnergy(numericProgramId, numericParticleId);
-      const maxE = service.getMaxEnergy(numericProgramId, numericParticleId);
-      const inRange: { rowId: string; energy: number }[] = [];
-      for (const item of uncachedItems) {
-        if (item.energy < minE || item.energy > maxE) {
-          newOutOfRange.add(item.rowId);
-          outOfRangeCache.add(oorCacheKey(item.energy));
-        } else {
-          inRange.push(item);
-        }
-      }
-      uncachedItems = inRange;
-    }
-
-    if (uncachedItems.length === 0) {
-      // All energies are OOR (from cache or range pre-check) — skip WASM entirely.
-      calculationResults = new Map();
-      outOfRangeRowIds = newOutOfRange;
-      isCalculating = false;
-      return;
-    }
-
-    try {
-      const result = callService(uncachedItems.map((e) => e.energy));
-      if (!result) {
-        calculationResults = new Map();
-        isCalculating = false;
-        return;
-      }
-      // Reassign to a new Map so Svelte detects the change.
-      calculationResults = processResults(result, uncachedItems);
-      outOfRangeRowIds = newOutOfRange;
-    } catch (e) {
-      if (e instanceof LibdedxError && e.code === 101 /* DEDX_ERR_ENERGY_OUT_OF_RANGE */) {
-        // Retry per-row to identify which energies are out of the tabulated range.
-        // This lets valid rows show results while out-of-range rows are marked individually.
-        const newResults = new Map<string, { stoppingPower: number; csdaRangeCm: number | null }>();
-        let fatalError: LibdedxError | null = null;
-
-        for (const item of uncachedItems) {
-          if (fatalError) break;
-          try {
-            const result = callService([item.energy]);
-            if (result) {
-              const entry = processResults(result, [item]).get(item.rowId);
-              if (entry) newResults.set(item.rowId, entry);
-            }
-          } catch (rowErr) {
-            if (rowErr instanceof LibdedxError && rowErr.code === 101) {
-              newOutOfRange.add(item.rowId);
-              outOfRangeCache.add(oorCacheKey(item.energy));
-            } else {
-              fatalError =
-                rowErr instanceof LibdedxError
-                  ? rowErr
-                  : new LibdedxError(-1, "Calculation failed");
-            }
-          }
-        }
-
-        calculationResults = newResults;
-        outOfRangeRowIds = newOutOfRange;
-        if (fatalError) error = fatalError;
-      } else {
-        error = e instanceof LibdedxError ? e : new LibdedxError(-1, "Calculation failed");
-      }
-    } finally {
-      isCalculating = false;
-    }
   }
 
   function getValidEnergies(): { rowId: string; energy: number }[] {
@@ -692,10 +358,10 @@ export function createCalculatorState(
       return inputState.isPerRowMode;
     },
     get isCalculating() {
-      return isCalculating;
+      return engine.isCalculating;
     },
     get error() {
-      return error;
+      return engine.error;
     },
     get validationSummary() {
       return computeValidationSummary();
@@ -788,18 +454,13 @@ export function createCalculatorState(
       return debouncedCalculate.flush();
     },
     clearResults() {
-      calculationResults = new Map();
-      outOfRangeRowIds = new Set();
-      isCalculating = false;
+      engine.clearResults();
     },
     resetAll() {
       entitySelection.resetAll();
       inputState.resetRows([{ text: "100" }]);
-      calculationResults = new Map();
-      outOfRangeRowIds = new Set();
-      outOfRangeCache.clear();
-      isCalculating = false;
-      error = null;
+      engine.clearResults();
+      engine.resetCache();
     },
     get hasLargeInput() {
       return inputState.hasLargeInput;

--- a/src/lib/state/calculator.svelte.ts
+++ b/src/lib/state/calculator.svelte.ts
@@ -5,10 +5,7 @@ import {
   convertEnergyFromMeVperNucl,
   getEnergyUnitCategory,
 } from "$lib/utils/energy-conversions";
-import {
-  formatSigFigs,
-  autoScaleLengthCm,
-} from "$lib/utils/unit-conversions";
+import { formatSigFigs, autoScaleLengthCm } from "$lib/utils/unit-conversions";
 import { LibdedxError } from "$lib/wasm/types";
 import type { EnergyUnit, StpUnit, LibdedxService } from "$lib/wasm/types";
 import type { EntitySelectionState } from "./entity-selection.svelte";
@@ -17,9 +14,7 @@ import type { ExternalOnlyParticle } from "./external-compatibility";
 import { debounce } from "$lib/utils/debounce";
 import { advancedOptions } from "./advanced-options.svelte";
 import { isAdvancedMode } from "./advanced-mode.svelte";
-import {
-  isCustomMaterial,
-} from "$lib/utils/custom-compound-material";
+import { isCustomMaterial } from "$lib/utils/custom-compound-material";
 import type { ExternalDataService } from "$lib/external-data/service";
 import { asBuiltinParticle, asBuiltinMaterial } from "$lib/utils/entity-type-guards";
 import { createCalculatorEngine } from "./calculator-engine.svelte";

--- a/src/lib/state/entity-selection.svelte.ts
+++ b/src/lib/state/entity-selection.svelte.ts
@@ -26,7 +26,11 @@ export interface AutoSelectProgram {
 
 export type SelectedProgram = ProgramEntity | AutoSelectProgram | ExternalProgramEntity;
 
-import { createMultiSelectionState, type PickerTabId, type AcrossDimension } from "./multi-selection.svelte";
+import {
+  createMultiSelectionState,
+  type PickerTabId,
+  type AcrossDimension,
+} from "./multi-selection.svelte";
 export type { PickerTabId, AcrossDimension };
 
 export interface EntitySelectionState {
@@ -537,13 +541,22 @@ export function createEntitySelectionState(matrix: CompatibilityMatrix): EntityS
       multiState.resetAll();
     },
 
-    get activeTarget() { return multiState.activeTarget; },
-    get expanded() { return multiState.expanded; },
-    get across() { return multiState.across; },
-    get multiSelected() { return multiState.multiSelected; },
+    get activeTarget() {
+      return multiState.activeTarget;
+    },
+    get expanded() {
+      return multiState.expanded;
+    },
+    get across() {
+      return multiState.across;
+    },
+    get multiSelected() {
+      return multiState.multiSelected;
+    },
     setActiveTarget: multiState.setActiveTarget,
     setExpanded: multiState.setExpanded,
-    setAcross: (newAcross: AcrossDimension) => multiState.setAcross(newAcross, selectedProgramId, selectedParticleId, selectedMaterialId),
+    setAcross: (newAcross: AcrossDimension) =>
+      multiState.setAcross(newAcross, selectedProgramId, selectedParticleId, selectedMaterialId),
     toggleMulti: multiState.toggleMulti,
     collapseToSingle: multiState.collapseToSingle,
     setMultiProgram: multiState.setMultiProgram,

--- a/src/lib/state/entity-selection.svelte.ts
+++ b/src/lib/state/entity-selection.svelte.ts
@@ -26,21 +26,8 @@ export interface AutoSelectProgram {
 
 export type SelectedProgram = ProgramEntity | AutoSelectProgram | ExternalProgramEntity;
 
-/**
- * Which of the three picker tabs is currently the "active target" — the tab
- * whose list opens when the user focuses the search field, marked by the
- * coral underline in `tab-bar.svelte`.
- */
-export type PickerTabId = "particle" | "material" | "program";
-
-/**
- * Compare-across dimension (Advanced mode). Controls the multi-entity result
- * view: `"single"` shows the standard single-entity result; `"material"` and
- * `"particle"` wire `multiSelected.material` / `multiSelected.particle` into
- * `TableMulti`; `"program"` drives the existing `MultiProgramState` result
- * table.
- */
-export type AcrossDimension = "single" | "particle" | "material" | "program";
+import { createMultiSelectionState, type PickerTabId, type AcrossDimension } from "./multi-selection.svelte";
+export type { PickerTabId, AcrossDimension };
 
 export interface EntitySelectionState {
   selectedProgram: SelectedProgram;
@@ -169,14 +156,7 @@ export function createEntitySelectionState(matrix: CompatibilityMatrix): EntityS
   let lastAutoFallbackMessage = $state<string | null>(null);
   let extCtx = $state<ExternalCompatibilityContext>(EMPTY_EXTERNAL_CONTEXT);
 
-  // New picker chrome state (entity-selector rework — see
-  // docs/04-feature-specs/entity-selection.md § Active target + expand/collapse).
-  let activeTarget = $state<PickerTabId>("particle");
-  let expanded = $state(true);
-  let across = $state<AcrossDimension>("single");
-  let multiParticle = $state<(number | string)[]>([]);
-  let multiMaterial = $state<(number | string)[]>([]);
-  let multiProgram = $state<(number | string)[]>([]);
+  const multiState = createMultiSelectionState();
 
   // Mobile picker sheet state (issue #530 — adaptive picker kit).
   let sheetOpen = $state(false);
@@ -554,105 +534,21 @@ export function createEntitySelectionState(matrix: CompatibilityMatrix): EntityS
       selectedMaterialId = WATER_ID;
       selectedProgramId = -1;
       lastAutoFallbackMessage = null;
-      activeTarget = "particle";
-      expanded = true;
-      across = "single";
-      multiParticle = [];
-      multiMaterial = [];
-      multiProgram = [];
+      multiState.resetAll();
     },
 
-    get activeTarget() {
-      return activeTarget;
-    },
-
-    get expanded() {
-      return expanded;
-    },
-
-    get across() {
-      return across;
-    },
-
-    get multiSelected() {
-      return {
-        particle: multiParticle,
-        material: multiMaterial,
-        program: multiProgram,
-      };
-    },
-
-    setActiveTarget(tab: PickerTabId): void {
-      activeTarget = tab;
-    },
-
-    setExpanded(value: boolean): void {
-      expanded = value;
-    },
-
-    setAcross(newAcross: AcrossDimension): void {
-      if (across === newAcross) return;
-      across = newAcross;
-      if (newAcross === "single") {
-        // Collapse all multi arrays to avoid stale selections bleeding in later.
-        if (multiParticle.length > 1) multiParticle = [multiParticle[0]!];
-        if (multiMaterial.length > 1) multiMaterial = [multiMaterial[0]!];
-        if (multiProgram.length > 1) multiProgram = [multiProgram[0]!];
-        // Don't force-open the picker or change the active tab.
-      } else {
-        // Seed multi array from current single value (preserves it as element 0).
-        if (newAcross === "program") {
-          const id = selectedProgramId;
-          multiProgram = id !== -1 ? [id] : [];
-        } else if (newAcross === "particle") {
-          multiParticle = selectedParticleId !== null ? [selectedParticleId] : [];
-        } else if (newAcross === "material") {
-          multiMaterial = selectedMaterialId !== null ? [selectedMaterialId] : [];
-        }
-        activeTarget = newAcross;
-        expanded = true;
-      }
-    },
-
-    toggleMulti(dim: AcrossDimension, id: number | string): void {
-      if (dim === "single") return;
-      const arr =
-        dim === "program" ? multiProgram : dim === "particle" ? multiParticle : multiMaterial;
-      const idx = arr.indexOf(id);
-      let next: (number | string)[];
-      if (idx >= 0) {
-        // Cannot deselect the default (first) entry — must reorder first.
-        if (idx === 0) return;
-        next = arr.filter((x) => x !== id);
-      } else {
-        next = [...arr, id];
-      }
-      if (dim === "program") multiProgram = next;
-      else if (dim === "particle") multiParticle = next;
-      else multiMaterial = next;
-    },
-
-    collapseToSingle(): void {
-      // Keep only the anchor (first) element in each multi array.
-      // If the array is empty, leave it empty (no selection to keep).
-      if (multiParticle.length > 1) multiParticle = [multiParticle[0]!];
-      if (multiMaterial.length > 1) multiMaterial = [multiMaterial[0]!];
-      if (multiProgram.length > 1) multiProgram = [multiProgram[0]!];
-    },
-
-    setMultiProgram(ids: (number | string)[]): void {
-      // Clone and de-dupe to prevent external mutation from bypassing $state
-      // reactivity and to ensure no duplicate IDs enter the internal state.
-      multiProgram = [...new Set(ids)];
-    },
-
-    setMultiMaterial(ids: (number | string)[]): void {
-      multiMaterial = [...new Set(ids)];
-    },
-
-    setMultiParticle(ids: (number | string)[]): void {
-      multiParticle = [...new Set(ids)];
-    },
+    get activeTarget() { return multiState.activeTarget; },
+    get expanded() { return multiState.expanded; },
+    get across() { return multiState.across; },
+    get multiSelected() { return multiState.multiSelected; },
+    setActiveTarget: multiState.setActiveTarget,
+    setExpanded: multiState.setExpanded,
+    setAcross: (newAcross: AcrossDimension) => multiState.setAcross(newAcross, selectedProgramId, selectedParticleId, selectedMaterialId),
+    toggleMulti: multiState.toggleMulti,
+    collapseToSingle: multiState.collapseToSingle,
+    setMultiProgram: multiState.setMultiProgram,
+    setMultiMaterial: multiState.setMultiMaterial,
+    setMultiParticle: multiState.setMultiParticle,
 
     get lastAutoFallbackMessage() {
       return lastAutoFallbackMessage;

--- a/src/lib/state/multi-selection.svelte.ts
+++ b/src/lib/state/multi-selection.svelte.ts
@@ -1,0 +1,123 @@
+export type PickerTabId = "particle" | "material" | "program";
+export type AcrossDimension = "single" | "particle" | "material" | "program";
+
+export interface MultiSelectionState {
+  activeTarget: PickerTabId;
+  expanded: boolean;
+  across: AcrossDimension;
+  multiSelected: {
+    particle: (number | string)[];
+    material: (number | string)[];
+    program: (number | string)[];
+  };
+  setActiveTarget(tab: PickerTabId): void;
+  setExpanded(expanded: boolean): void;
+  setAcross(
+    newAcross: AcrossDimension,
+    currentSingleProgramId: number | string,
+    currentSingleParticleId: number | string | null,
+    currentSingleMaterialId: number | string | null,
+  ): void;
+  toggleMulti(dim: AcrossDimension, id: number | string): void;
+  collapseToSingle(): void;
+  setMultiProgram(ids: (number | string)[]): void;
+  setMultiMaterial(ids: (number | string)[]): void;
+  setMultiParticle(ids: (number | string)[]): void;
+  resetAll(): void;
+}
+
+export function createMultiSelectionState(): MultiSelectionState {
+  let activeTarget = $state<PickerTabId>("particle");
+  let expanded = $state(true);
+  let across = $state<AcrossDimension>("single");
+  let multiParticle = $state<(number | string)[]>([]);
+  let multiMaterial = $state<(number | string)[]>([]);
+  let multiProgram = $state<(number | string)[]>([]);
+
+  return {
+    get activeTarget() {
+      return activeTarget;
+    },
+    get expanded() {
+      return expanded;
+    },
+    get across() {
+      return across;
+    },
+    get multiSelected() {
+      return {
+        particle: multiParticle,
+        material: multiMaterial,
+        program: multiProgram,
+      };
+    },
+    setActiveTarget(tab: PickerTabId) {
+      activeTarget = tab;
+    },
+    setExpanded(value: boolean) {
+      expanded = value;
+    },
+    setAcross(
+      newAcross: AcrossDimension,
+      currentSingleProgramId: number | string,
+      currentSingleParticleId: number | string | null,
+      currentSingleMaterialId: number | string | null,
+    ) {
+      if (across === newAcross) return;
+      across = newAcross;
+      if (newAcross === "single") {
+        if (multiParticle.length > 1) multiParticle = [multiParticle[0]!];
+        if (multiMaterial.length > 1) multiMaterial = [multiMaterial[0]!];
+        if (multiProgram.length > 1) multiProgram = [multiProgram[0]!];
+      } else {
+        if (newAcross === "program") {
+          multiProgram = currentSingleProgramId !== -1 ? [currentSingleProgramId] : [];
+        } else if (newAcross === "particle") {
+          multiParticle = currentSingleParticleId !== null ? [currentSingleParticleId] : [];
+        } else if (newAcross === "material") {
+          multiMaterial = currentSingleMaterialId !== null ? [currentSingleMaterialId] : [];
+        }
+        activeTarget = newAcross;
+        expanded = true;
+      }
+    },
+    toggleMulti(dim: AcrossDimension, id: number | string) {
+      if (dim === "single") return;
+      const arr =
+        dim === "program" ? multiProgram : dim === "particle" ? multiParticle : multiMaterial;
+      const idx = arr.indexOf(id);
+      let next: (number | string)[];
+      if (idx >= 0) {
+        if (idx === 0) return;
+        next = arr.filter((x) => x !== id);
+      } else {
+        next = [...arr, id];
+      }
+      if (dim === "program") multiProgram = next;
+      else if (dim === "particle") multiParticle = next;
+      else multiMaterial = next;
+    },
+    collapseToSingle() {
+      if (multiParticle.length > 1) multiParticle = [multiParticle[0]!];
+      if (multiMaterial.length > 1) multiMaterial = [multiMaterial[0]!];
+      if (multiProgram.length > 1) multiProgram = [multiProgram[0]!];
+    },
+    setMultiProgram(ids: (number | string)[]) {
+      multiProgram = [...new Set(ids)];
+    },
+    setMultiMaterial(ids: (number | string)[]) {
+      multiMaterial = [...new Set(ids)];
+    },
+    setMultiParticle(ids: (number | string)[]) {
+      multiParticle = [...new Set(ids)];
+    },
+    resetAll() {
+      activeTarget = "particle";
+      expanded = true;
+      across = "single";
+      multiParticle = [];
+      multiMaterial = [];
+      multiProgram = [];
+    },
+  };
+}

--- a/src/lib/state/multi-selection.svelte.ts
+++ b/src/lib/state/multi-selection.svelte.ts
@@ -1,4 +1,6 @@
+/** Picker tab IDs used by the entity selection panel state/UI. */
 export type PickerTabId = "particle" | "material" | "program";
+/** Compare-across dimension; "single" disables multi-selection mode. */
 export type AcrossDimension = "single" | "particle" | "material" | "program";
 
 export interface MultiSelectionState {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -91,7 +91,9 @@
                 data-testid="export-pdf-btn"
                 variant="outline"
                 size="sm"
+                class="text-foreground"
                 disabled={!canExport.value}
+                aria-disabled={!canExport.value}
                 aria-label="Export PDF"
                 onclick={() => {
                   if (routePath === "/calculator") exportPdf();
@@ -104,7 +106,9 @@
                 data-testid="export-csv-btn"
                 variant="outline"
                 size="sm"
+                class="text-foreground"
                 disabled={!canExport.value}
+                aria-disabled={!canExport.value}
                 aria-label="Export CSV"
                 onclick={() => {
                   if (routePath === "/calculator") {


### PR DESCRIPTION
## Description
This PR addresses issue #628 by breaking down monolithic state management files into smaller, more cohesive Svelte 5 modules to improve readability, maintainability, and separation of concerns.

### Key Changes
1. **Calculator Engine Extraction**:
   - Extracted asynchronous WASM logic and caching mechanisms from `calculator.svelte.ts` into a dedicated `calculator-engine.svelte.ts`.
   - Refactored `calculator.svelte.ts` to consume the engine instance, streamlining calculation pipelines and removing duplicate logic.

2. **Entity Selection Extraction**:
   - Extracted complex multi-selection logic (e.g., `across` dimension, array management) from `entity-selection.svelte.ts` into a new `multi-selection.svelte.ts` module.
   - Refactored the core `entity-selection.svelte.ts` to delegate interactions to this sub-state module.

3. **Accessibility (A11y) Bug Fix**:
   - Resolved a failing E2E Playwright test related to `color-contrast` WCAG violations for the export buttons in `src/routes/+layout.svelte`.
   - Added `aria-disabled={!canExport.value}` to properly mark the button status for screen readers.
   - Added `class="text-foreground"` to ensure proper contrast ratios are met when buttons are enabled.

## Verification
- [x] Unit tests pass locally.
- [x] E2E Playwright accessibility tests are fixed and pass.
- [x] Formatting and strict static tests (`pnpm run format`, `pnpm guard:staged`) pass.
- [x] AI session logs tracking these changes have been committed.