### PR TITLE
fix: remove redundant "Plot" heading from plot page

### DIFF
--- a/src/routes/plot/+page.svelte
+++ b/src/routes/plot/+page.svelte
@@ -109,6 +109,8 @@
   <title>Plot - webdedx</title>
 </svelte:head>
 
+<h1 class="sr-only">Plot</h1>
+
 {#if wasmError.value}
   <div class="space-y-6">
     <div

--- a/src/routes/plot/+page.svelte
+++ b/src/routes/plot/+page.svelte
@@ -111,7 +111,6 @@
 
 {#if wasmError.value}
   <div class="space-y-6">
-    <h1 class="text-3xl font-bold">Plot</h1>
     <div
       class="mx-auto max-w-md rounded-lg border border-destructive bg-destructive/10 p-8 text-center space-y-4"
     >
@@ -130,7 +129,6 @@
   </div>
 {:else if externalError}
   <div class="space-y-6">
-    <h1 class="text-3xl font-bold">Plot</h1>
     <div
       class="mx-auto max-w-md rounded-lg border border-destructive bg-destructive/10 p-8 text-center space-y-4"
     >
@@ -148,7 +146,6 @@
   </div>
 {:else if !wasmReady.value || !entityState}
   <div class="space-y-6">
-    <h1 class="text-3xl font-bold">Plot</h1>
     <div
       class="mx-auto max-w-4xl space-y-6"
       role="status"
@@ -170,8 +167,6 @@
   </div>
 {:else}
   <div class="space-y-4">
-    <h1 class="text-3xl font-bold">Plot</h1>
-
     {#if orchestrator.urlVersionMismatch}
       <UrlVersionWarningBanner
         version={orchestrator.urlVersionMismatch.version}

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -1,14 +1,13 @@
 import { test, expect } from "@playwright/test";
 
-const appPages = ["/calculator", "/plot", "/docs"];
-
-const pageHeadings = [
+const appPages = [
   { path: "/calculator", heading: "Calculator" },
+  { path: "/plot", heading: "Plot" },
   { path: "/docs", heading: "Documentation" },
 ];
 
 test.describe("Navigation bar", () => {
-  for (const path of appPages) {
+  for (const { path } of appPages) {
     test(`nav bar is visible on ${path}`, async ({ page }) => {
       await page.goto(path);
       await expect(page.locator("nav")).toBeVisible();
@@ -37,7 +36,7 @@ test.describe("Navigation bar", () => {
 });
 
 test.describe("Footer", () => {
-  for (const path of appPages) {
+  for (const { path } of appPages) {
     test(`footer is visible on ${path}`, async ({ page }) => {
       await page.goto(path);
       await expect(page.locator("footer")).toBeVisible();
@@ -51,7 +50,7 @@ test.describe("Footer", () => {
 });
 
 test.describe("Page headings", () => {
-  for (const { path, heading } of pageHeadings) {
+  for (const { path, heading } of appPages) {
     test(`${path} has h1 "${heading}"`, async ({ page }) => {
       await page.goto(path);
       await expect(page.getByRole("heading", { level: 1, name: heading })).toBeVisible();

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -1,13 +1,14 @@
 import { test, expect } from "@playwright/test";
 
-const appPages = [
+const appPages = ["/calculator", "/plot", "/docs"];
+
+const pageHeadings = [
   { path: "/calculator", heading: "Calculator" },
-  { path: "/plot", heading: "Plot" },
   { path: "/docs", heading: "Documentation" },
 ];
 
 test.describe("Navigation bar", () => {
-  for (const { path } of appPages) {
+  for (const path of appPages) {
     test(`nav bar is visible on ${path}`, async ({ page }) => {
       await page.goto(path);
       await expect(page.locator("nav")).toBeVisible();
@@ -36,7 +37,7 @@ test.describe("Navigation bar", () => {
 });
 
 test.describe("Footer", () => {
-  for (const { path } of appPages) {
+  for (const path of appPages) {
     test(`footer is visible on ${path}`, async ({ page }) => {
       await page.goto(path);
       await expect(page.locator("footer")).toBeVisible();
@@ -50,7 +51,7 @@ test.describe("Footer", () => {
 });
 
 test.describe("Page headings", () => {
-  for (const { path, heading } of appPages) {
+  for (const { path, heading } of pageHeadings) {
     test(`${path} has h1 "${heading}"`, async ({ page }) => {
       await page.goto(path);
       await expect(page.getByRole("heading", { level: 1, name: heading })).toBeVisible();


### PR DESCRIPTION
## Summary

- Removes the `<h1>Plot</h1>` heading from all four render branches on the plot page (wasm error, external error, loading skeleton, and main content)
- The active nav tab already communicates which page the user is on, making the heading redundant and wasteful of vertical space

Closes #623

## Test plan

- [ ] Visit `/plot` — no "Plot" heading visible below the nav tabs
- [ ] Trigger loading state (slow network) — no heading in skeleton UI
- [ ] Check that error states (wasm/external) also have no heading

---
_Generated by [Claude Code](https://claude.ai/code/session_016VxuxrPRChMjiweMEzZABy)_