### PR TITLE
test(url): clean up legacy urlv=1 tests and add v2 coverage (#632)

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -17,6 +17,9 @@ Use one bullet per session (newest first):
 
 ## Entries (newest first)
 
+- 2026-05-29 — **Testing**: Clean up legacy URL tests in `calculator-url.test.ts` (Issue #632): labeled all `urlv=1` fixtures as legacy migration tests, updated non-migration tests to use `urlv=2`, added 8 new v2 tests covering `mode=basic`, `across=programs` encode/decode, `urlv=2` canonical decode, and `qfocus=both` migration round-trips. (Claude Sonnet 4.6 via Claude Code)
+  - **Log:** [log](docs/ai-logs/2026-05-29-issue-632-url-test-cleanup.md)
+
 - 2026-05-29 — **Stage 6.10**: Reimplemented compound editor live derived UI & mass-% validation (Issue #645) cleanly on master — pure `$derived` Save gating, formula footer (Unicode formula · atom count · Bragg I-value), weight-fraction sum tracker with auto-rescale, and live per-row mass-%. Fixes the duplicate-element Save-gating regression from PR #653 (the formula footer's keyed `{#each}` crashed on duplicate Z, leaving Save enabled). (Claude Opus 4.8 via Claude Code)
   - **Log:** [log](docs/ai-logs/2026-05-29-issue-645-derived-ui.md)
 

--- a/docs/ai-logs/2026-05-29-issue-632-url-test-cleanup.md
+++ b/docs/ai-logs/2026-05-29-issue-632-url-test-cleanup.md
@@ -1,0 +1,75 @@
+# 2026-05-29 — Clean up legacy URL tests (Issue #632)
+
+## Session Narrative
+
+### Prompt 1: Work on issue #632 — clean up legacy URL tests; ensure v2 unit tests cover all necessary scenarios; make a PR
+
+**AI response**: Read issue #632, the test file `src/tests/unit/calculator-url.test.ts`, the
+source `src/lib/utils/calculator-url.ts`, and the spec `docs/04-feature-specs/shareable-urls.md`.
+
+Identified all `urlv=1` occurrences in the test file and classified each as:
+- *Non-migration* (urlv=1 was incidental, not testing v1-specific params) → updated to `urlv=2`
+- *Migration-specific* (used v1-only params like `qfocus=`) → moved to the migration `describe` block
+
+Also identified missing v2 coverage: `mode=basic` explicit decode, `across=programs`
+encode/decode, and `urlv=2` canonical decode.
+
+## Tasks
+
+### Reclassify `urlv=1` tests in `describe("decodeCalculatorUrl")`
+
+- **Status**: completed
+- **Files changed**: `src/tests/unit/calculator-url.test.ts`
+- **Decision**: Changed `urlv=1` to `urlv=2` in 3 tests where urlv was incidental.
+  Removed 2 tests that used v1-only `qfocus=both` param (moved to migration section
+  with improved descriptions).
+- **Tests changed**:
+  - "decodes basic params" — urlv=1 → urlv=2
+  - "decodes advanced mode with invalid program IDs" — urlv=1 → urlv=2; dropped incidental `qfocus=both`
+  - "decodeCalculatorUrl returns advancedOptions only in advanced mode" — urlv=1 → urlv=2
+
+### Replace v1 "parses all advanced options" test with v2 equivalent
+
+- **Status**: completed
+- **Decision**: Removed the v1 version from `describe("decodeCalculatorUrl")` and added a clean
+  `urlv=2` version ("decodeCalculatorUrl parses all advanced options correctly (v2 canonical params)").
+  Moved the v1 version to the migration section under "v1 parses all advanced options with qfocus=both".
+
+### Remove v1 round-trip test from `describe("decodeCalculatorUrl")`
+
+- **Status**: completed
+- **Decision**: Moved "URL round-trip: encode(decode(url)) preserves all advanced options" (which used
+  `urlv=1&qfocus=both`) to the migration section as "v1 round-trip: qfocus=both normalises to default
+  and all advanced options are preserved". Added assertion that `qshow` is absent after round-trip.
+
+### Improve migration section label and block comment
+
+- **Status**: completed
+- **Decision**: Rewrote the migration `describe` block comment to clearly state: these tests
+  verify backward-compatibility for old bookmarks; they do NOT reflect the canonical v2 encoding.
+  Listed the key v1→v2 renames/removals.
+
+### Update `describe("unknown params dropped")` section
+
+- **Status**: completed
+- **Decision**: Added comment explaining that `urlv=1` in the existing test is intentional (tests
+  the v1→v2 upgrade path). Added a sister test with `urlv=2` input to show unknown params are
+  dropped even without the upgrade path.
+
+### Add missing v2 tests
+
+- **Status**: completed
+- **Tests added**:
+  - "explicit mode=basic is treated as basic mode (not advanced)" — in `describe("decodeCalculatorUrl")`
+  - "unknown params absent from encoded output with urlv=2 input" — in `describe("unknown params dropped")`
+  - "v1 round-trip: qfocus=both normalises to default and all advanced options are preserved" — in migration
+  - "v1 parses all advanced options with qfocus=both (legacy qfocus param)" — in migration
+  - "emits across=programs when across is program" — in `describe("encodeCalculatorUrl — multi-particle")`
+  - "decodes across=programs and populates selectedProgramIds" — in `describe("decodeCalculatorUrl — multi-particle")`
+  - "accepts legacy singular across=program for backward compatibility" — in `describe("decodeCalculatorUrl — multi-particle")`
+
+### Result
+
+- Net: deleted 2 tests, added 8 tests (+6 total). All 1581 tests pass (pre-existing 3 failures
+  unrelated: git-signing infrastructure in CI).
+- `pnpm format` and `pnpm run format:check` both clean.

--- a/src/tests/unit/calculator-url.test.ts
+++ b/src/tests/unit/calculator-url.test.ts
@@ -165,7 +165,7 @@ describe("calculatorUrlQueryString", () => {
 describe("decodeCalculatorUrl", () => {
   it("decodes basic params", () => {
     const params = new URLSearchParams(
-      "urlv=1&particle=1&material=276&program=auto&energies=100,200&eunit=MeV",
+      "urlv=2&particle=1&material=276&program=auto&energies=100,200&eunit=MeV",
     );
     const s = decodeCalculatorUrl(params);
     expect(s.particleId).toBe(1);
@@ -264,7 +264,7 @@ describe("decodeCalculatorUrl", () => {
 
   it("decodes advanced mode with invalid program IDs (no crash, IDs parsed as integers)", () => {
     const params = new URLSearchParams(
-      "urlv=1&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9%2C999&qfocus=both",
+      "urlv=2&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9%2C999",
     );
     const s = decodeCalculatorUrl(params);
     // Decoder parses all positive integers; validation against available programs happens at state level
@@ -472,22 +472,6 @@ describe("decodeCalculatorUrl", () => {
     expect(p.get("ival")).toBe("85.5");
   });
 
-  it("URL round-trip: encode(decode(url)) preserves all advanced options", () => {
-    const originalParams = new URLSearchParams(
-      "urlv=1&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9&qfocus=both&agg_state=gas&interp_scale=lin-lin&interp_method=spline&mstar_mode=a&density=1.5&ival=85.5",
-    );
-    const decoded = decodeCalculatorUrl(originalParams);
-    const reEncoded = encodeCalculatorUrl(decoded);
-
-    expect(reEncoded.get("mode")).toBe("advanced");
-    expect(reEncoded.get("agg_state")).toBe("gas");
-    expect(reEncoded.get("interp_scale")).toBe("lin-lin");
-    expect(reEncoded.get("interp_method")).toBe("spline");
-    expect(reEncoded.get("mstar_mode")).toBe("a");
-    expect(reEncoded.get("density")).toBe("1.5");
-    expect(reEncoded.get("ival")).toBe("85.5");
-  });
-
   it("URL round-trip with partial params: encode(decode(url)) normalises qshow=stp to absent", () => {
     const originalParams = new URLSearchParams(
       "urlv=2&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9&qshow=stp&density=1.5",
@@ -509,16 +493,26 @@ describe("decodeCalculatorUrl", () => {
 
   it("decodeCalculatorUrl returns advancedOptions only in advanced mode", () => {
     const params = new URLSearchParams(
-      "urlv=1&particle=1&material=276&program=auto&energies=100&eunit=MeV&agg_state=gas",
+      "urlv=2&particle=1&material=276&program=auto&energies=100&eunit=MeV&agg_state=gas",
     );
     const decoded = decodeCalculatorUrl(params);
     // Without mode=advanced, agg_state is ignored
     expect(decoded.advancedOptions).toBeUndefined();
   });
 
-  it("decodeCalculatorUrl parses all advanced options correctly", () => {
+  it("explicit mode=basic is treated as basic mode (not advanced)", () => {
     const params = new URLSearchParams(
-      "urlv=1&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9&qfocus=both&agg_state=condensed&interp_scale=lin-lin&interp_method=spline&mstar_mode=c&density=2.0&ival=100",
+      "urlv=2&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=basic",
+    );
+    const state = decodeCalculatorUrl(params);
+    expect(state.isAdvancedMode).toBe(false);
+    expect(state.across).toBeUndefined();
+    expect(state.selectedProgramIds).toBeUndefined();
+  });
+
+  it("decodeCalculatorUrl parses all advanced options correctly (v2 canonical params)", () => {
+    const params = new URLSearchParams(
+      "urlv=2&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9&agg_state=condensed&interp_scale=lin-lin&interp_method=spline&mstar_mode=c&density=2.0&ival=100",
     );
     const decoded = decodeCalculatorUrl(params);
     expect(decoded.isAdvancedMode).toBe(true);
@@ -701,9 +695,24 @@ describe("duplicate params — last wins (§3.2)", () => {
 // ──────────────────────────────────────────────────────────────────────────
 
 describe("unknown params dropped from canonical URL", () => {
-  it("unknown foo=bar is absent from encoded output", () => {
+  it("unknown foo=bar is absent from encoded output; urlv=1 input is upgraded to urlv=2", () => {
+    // urlv=1 here is intentional: also tests that a v1 bookmark is silently upgraded to v2
+    // by the encode/decode round-trip.
     const params = new URLSearchParams(
       "urlv=1&particle=1&material=276&program=auto&energies=100&eunit=MeV&foo=bar&unknown=xyz",
+    );
+    const state = decodeCalculatorUrl(params);
+    const encoded = encodeCalculatorUrl(state);
+    const encodedStr = encoded.toString();
+    expect(encodedStr).not.toContain("foo=");
+    expect(encodedStr).not.toContain("unknown=");
+    expect(encodedStr).toContain("urlv=2");
+    expect(encodedStr).toContain("particle=1");
+  });
+
+  it("unknown params absent from encoded output with urlv=2 input", () => {
+    const params = new URLSearchParams(
+      "urlv=2&particle=1&material=276&program=auto&energies=100&eunit=MeV&foo=bar&unknown=xyz",
     );
     const state = decodeCalculatorUrl(params);
     const encoded = encodeCalculatorUrl(state);
@@ -716,17 +725,19 @@ describe("unknown params dropped from canonical URL", () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────
-// v1 → v2 migration fixtures (shareable-urls.md §7)
+// LEGACY MIGRATION TESTS — v1 → v2 (shareable-urls.md §7)
 //
-// These tests anchor the v1→v2 migration mapping that the schema doc
-// describes. The current v1 decoder is what's being tested here — once the
-// v2 encoder/decoder lands in #555–#561, these fixtures will be updated to
-// assert the v2 canonical output and v2 migration behaviour.
+// These tests verify backward-compatibility: old bookmarks/shared URLs that
+// carry `urlv=1` (or no urlv) must decode correctly under the v2 decoder.
+// None of the assertions here reflect the canonical v2 encoding — they
+// anchor the migration mapping so that changes to the decoder cannot silently
+// break existing bookmarks.
 //
-// NOTE: v2 keeps the param names particle=, material=, program= verbatim
-// (the earlier rename to *Id was reverted, see ADR 006 §3). The only v1
-// param renames in v2 are around eunit→uanchor, qfocus→qshow, imode→mode,
-// and the silent drop of hidden_programs=.
+// Key v1 → v2 renames / removals (ADR 006):
+//   • qfocus=stp|csda|both  →  qshow=stp|range (2-state; "both" → omit)
+//   • ivalues=              →  lookups= (accepted as fallback read-only)
+//   • hidden_programs=      →  silently dropped
+//   • particle=, material=, program= names are UNCHANGED (ADR 006 §3)
 //
 // Source of truth: docs/04-feature-specs/shareable-urls.md §7 (migration rules)
 //                  docs/decisions/006-url-schema-v2.md (justification)
@@ -881,6 +892,44 @@ describe("v1 → v2 migration fixture (shareable-urls.md §7)", () => {
       { rawInput: "45", unit: "um", unitFromSuffix: true },
     ]);
   });
+
+  it("v1 round-trip: qfocus=both normalises to default and all advanced options are preserved", () => {
+    // qfocus=both was the old "show both STP and Range" default; in v2 it maps to
+    // quantityFocus=undefined (omitted). The round-trip verifies that all other
+    // advanced options survive the v1→v2 migration path.
+    const originalParams = new URLSearchParams(
+      "urlv=1&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9&qfocus=both&agg_state=gas&interp_scale=lin-lin&interp_method=spline&mstar_mode=a&density=1.5&ival=85.5",
+    );
+    const decoded = decodeCalculatorUrl(originalParams);
+    const reEncoded = encodeCalculatorUrl(decoded);
+
+    expect(reEncoded.get("mode")).toBe("advanced");
+    expect(reEncoded.has("qshow")).toBe(false); // qfocus=both → omit (v2 default)
+    expect(reEncoded.get("agg_state")).toBe("gas");
+    expect(reEncoded.get("interp_scale")).toBe("lin-lin");
+    expect(reEncoded.get("interp_method")).toBe("spline");
+    expect(reEncoded.get("mstar_mode")).toBe("a");
+    expect(reEncoded.get("density")).toBe("1.5");
+    expect(reEncoded.get("ival")).toBe("85.5");
+  });
+
+  it("v1 parses all advanced options with qfocus=both (legacy qfocus param)", () => {
+    // qfocus=both is the old default that maps to quantityFocus=undefined in v2.
+    // This fixture ensures the decoder still parses all advanced options from a
+    // v1 URL that happens to carry the qfocus= param.
+    const params = new URLSearchParams(
+      "urlv=1&particle=1&material=276&program=auto&energies=100&eunit=MeV&mode=advanced&programs=9&qfocus=both&agg_state=condensed&interp_scale=lin-lin&interp_method=spline&mstar_mode=c&density=2.0&ival=100",
+    );
+    const decoded = decodeCalculatorUrl(params);
+    expect(decoded.isAdvancedMode).toBe(true);
+    expect(decoded.quantityFocus).toBeUndefined(); // qfocus=both → omit (v2 default)
+    expect(decoded.advancedOptions?.aggregateState).toBe("condensed");
+    expect(decoded.advancedOptions?.interpolation?.scale).toBe("linear");
+    expect(decoded.advancedOptions?.interpolation?.method).toBe("cubic");
+    expect(decoded.advancedOptions?.mstarMode).toBe("c");
+    expect(decoded.advancedOptions?.densityOverride).toBe(2.0);
+    expect(decoded.advancedOptions?.iValueOverride).toBe(100);
+  });
 });
 
 // ─── Multi-particle URL encoding/decoding (issue #599) ────────────────────────
@@ -930,6 +979,16 @@ describe("encodeCalculatorUrl — multi-particle (across=particles)", () => {
     });
     expect(p.get("across")).toBe("materials");
     expect(p.has("particles")).toBe(false);
+  });
+
+  it("emits across=programs when across is program", () => {
+    const p = encodeCalculatorUrl({
+      ...advancedBase,
+      across: "program",
+      selectedProgramIds: [9, 2],
+    });
+    expect(p.get("across")).toBe("programs");
+    expect(p.get("programs")).toBe("9,2");
   });
 
   it("round-trips the canonical spec example URL", () => {
@@ -1010,5 +1069,24 @@ describe("decodeCalculatorUrl — multi-particle (across=particles)", () => {
     const state = decodeCalculatorUrl(params);
     expect(state.across).toBe("material");
     expect(state.selectedParticleIds).toBeUndefined();
+  });
+
+  it("decodes across=programs and populates selectedProgramIds", () => {
+    const params = new URLSearchParams(
+      "urlv=2&mode=advanced&particle=1&material=276&program=9&programs=9,2&energies=100&eunit=MeV&across=programs",
+    );
+    const state = decodeCalculatorUrl(params);
+    expect(state.across).toBe("program");
+    expect(state.selectedProgramIds).toEqual([9, 2]);
+    expect(state.selectedParticleIds).toBeUndefined();
+  });
+
+  it("accepts legacy singular across=program for backward compatibility", () => {
+    const params = new URLSearchParams(
+      "urlv=2&mode=advanced&particle=1&material=276&program=9&programs=9,2&energies=100&eunit=MeV&across=program",
+    );
+    const state = decodeCalculatorUrl(params);
+    expect(state.across).toBe("program");
+    expect(state.selectedProgramIds).toEqual([9, 2]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #632.

- **Reclassify non-migration `urlv=1` tests to `urlv=2`**: Three tests in `describe("decodeCalculatorUrl")` had incidental `urlv=1` in their URLs (basic params, invalid program IDs, advancedOptions-only-in-advanced-mode). Updated to `urlv=2`.
- **Move migration-specific tests to the legacy section**: Two tests that relied on v1-only `qfocus=` param were removed from the main decode section and placed in the `v1 → v2 migration fixture` block with clearer descriptions.
- **Strengthen the migration block comment**: Rewrites the header to explicitly state these are backward-compatibility fixtures, not canonical v2 encoding, and lists the key v1→v2 renames/removals.
- **New v2 tests added** (8 total, net +6):
  - `mode=basic` explicit decode is not advanced mode
  - `across=programs` encode emits `across=programs` token
  - `across=programs` decode populates `selectedProgramIds`
  - Legacy singular `across=program` accepted as backward-compat
  - `urlv=2` canonical advanced-options decode (replacing the deleted v1 version)
  - Sister test for unknown-params-dropped with `urlv=2` input
  - Two v1 legacy fixtures in migration section with improved assertions

## Test plan

- [x] `pnpm test` — 1581 unit tests pass (3 pre-existing failures in `guard-forbidden-files` due to git-signing infrastructure, unrelated to this PR)
- [x] `pnpm run format:check` — clean
- [ ] E2E tests will run in CI

https://claude.ai/code/session_016fuCbE1KYG4wJmyjphd4pJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016fuCbE1KYG4wJmyjphd4pJ)_