### PR TITLE
feat(custom-compounds): implement Quick Start panel and default to LiF

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -17,6 +17,9 @@ Use one bullet per session (newest first):
 
 ## Entries (newest first)
 
+- 2026-05-29 — **Stage 5**: Implement Quick Start panel & default to LiF (Antigravity via Google DeepMind)
+  - **Log:** [log](docs/ai-logs/2026-05-29-issue-646.md)
+
 - 2026-05-29 — **Stage 6.10**: Reimplemented compound editor live derived UI & mass-% validation (Issue #645) cleanly on master — pure `$derived` Save gating, formula footer (Unicode formula · atom count · Bragg I-value), weight-fraction sum tracker with auto-rescale, and live per-row mass-%. Fixes the duplicate-element Save-gating regression from PR #653 (the formula footer's keyed `{#each}` crashed on duplicate Z, leaving Save enabled). (Claude Opus 4.8 via Claude Code)
   - **Log:** [log](docs/ai-logs/2026-05-29-issue-645-derived-ui.md)
 

--- a/docs/ai-logs/2026-05-29-issue-646.md
+++ b/docs/ai-logs/2026-05-29-issue-646.md
@@ -1,0 +1,27 @@
+# 2026-05-29 — Issue 646: Quick Start Panel & LiF Default
+
+## Session Narrative
+
+### Prompt 1: work on https://github.com/APTG/dedx_web/issues/646 , create branch first, you commit, I push. remember about AI logs. Ensure all tests required by GHA will pass: static, E2E. use `gh` tool to read issue contents.
+
+**AI response**: Read the issue using `gh`, analyzed requirements, and created branch `qwen/issue-646`. Designed `QuickStartPanel` and `compound-presets.ts`.
+
+### Prompt 2: You can start with LiF to avoid empty state, adjust plan
+
+**AI response**: Updated implementation to use LiF (Z=3, Z=9) as the default composition instead of H. Built the `QuickStartPanel` with predefined presets (Water, Air, Tissue, Kapton) and a parser to handle pasted formulas (e.g., `H2O`, `C6H12O6`). Updated e2e and unit tests to accommodate the change from H to LiF default. Fixed e2e test `custom-compounds.spec.ts` failures related to assumption that initial state was `H`.
+
+## Tasks
+
+### Implement Quick Start panel & LiF Default
+
+- **Status**: completed
+- **Stage**: Stage 5 (Calculator Panel Implementation)
+- **Files changed**:
+  - `src/lib/data/compound-presets.ts`
+  - `src/lib/components/compound-editor/quick-start-panel.svelte`
+  - `src/lib/components/compound-editor-modal.svelte`
+  - `src/tests/components/compound-editor-modal.test.ts`
+  - `tests/e2e/custom-compounds.spec.ts`
+  - `CHANGELOG-AI.md`
+- **Decision**: Made LiF the default material. Removed H. Implemented `onApplyPreset` and `handlePasteFormula` to modify `formData.elements` safely.
+- **Issue**: An unrelated test failure in `accessibility.spec.ts` (export-pdf-btn color contrast) remains unfixed, as it is outside the scope of Issue #646.

--- a/docs/ai-logs/2026-05-29-issue-646.md
+++ b/docs/ai-logs/2026-05-29-issue-646.md
@@ -8,7 +8,7 @@
 
 ### Prompt 2: You can start with LiF to avoid empty state, adjust plan
 
-**AI response**: Updated implementation to use LiF (Z=3, Z=9) as the default composition instead of H. Built the `QuickStartPanel` with predefined presets (Water, Air, Tissue, Kapton) and a parser to handle pasted formulas (e.g., `H2O`, `C6H12O6`). Updated e2e and unit tests to accommodate the change from H to LiF default. Fixed e2e test `custom-compounds.spec.ts` failures related to assumption that initial state was `H`.
+**AI response**: Updated implementation to use LiF (Z=3, Z=9) as the default composition instead of H. Built the `QuickStartPanel` with predefined presets (Water, A-150, Bone, Muscle, Lung, Air) and a parser to handle pasted formulas (e.g., `H2O`, `C6H12O6`). Updated e2e and unit tests to accommodate the change from H to LiF default. Fixed e2e test `custom-compounds.spec.ts` failures related to assumption that initial state was `H`.
 
 ## Tasks
 

--- a/src/lib/components/compound-editor-modal.svelte
+++ b/src/lib/components/compound-editor-modal.svelte
@@ -69,6 +69,7 @@
   let showDeleteConfirm = $state(false);
   let compositionTouched = $state(false);
   let presetToConfirm = $state<CompoundPreset | null>(null);
+  let formulaToConfirm = $state<ParsedElement[] | null>(null);
 
   let isEmptyComposition = $derived(
     formData.elements.length === 0 || (!compositionTouched && !compound),
@@ -377,8 +378,8 @@
     compositionTouched = true;
   }
 
-  function handlePasteFormula(elements: ParsedElement[]) {
-    if (isEmptyComposition) {
+  function applyPasteFormulaData(elements: ParsedElement[], replace: boolean) {
+    if (replace) {
       formData.elements = [];
       elementTexts = [];
       if (mode === "weight") weightTexts = [];
@@ -398,6 +399,15 @@
       weightTexts = computeInitialWeightTexts(formData.elements);
     }
     compositionTouched = true;
+    formulaToConfirm = null;
+  }
+
+  function handlePasteFormula(elements: ParsedElement[]) {
+    if (isEmptyComposition) {
+      applyPasteFormulaData(elements, true);
+    } else {
+      formulaToConfirm = elements;
+    }
   }
 
   function applyPresetData(preset: CompoundPreset) {
@@ -970,6 +980,43 @@
             Cancel
           </Button>
           <Button variant="default" onclick={() => applyPresetData(presetToConfirm!)}>
+            Replace
+          </Button>
+        </div>
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+{/if}
+
+{#if formulaToConfirm}
+  <Dialog.Root
+    open={!!formulaToConfirm}
+    onOpenChange={(o) => {
+      if (!o) formulaToConfirm = null;
+    }}
+  >
+    <Dialog.Portal>
+      <Dialog.Overlay class="fixed inset-0 z-[60] bg-black/80" />
+      <Dialog.Content
+        class="fixed left-[50%] top-[50%] z-[60] w-full max-w-sm translate-x-[-50%] translate-y-[-50%] rounded-md border bg-background p-6 shadow-lg"
+      >
+        <Dialog.Title class="text-lg font-semibold">Paste Formula</Dialog.Title>
+        <p class="mt-2 text-sm text-muted-foreground">
+          Do you want to replace your current composition with the pasted formula, or append to it?
+        </p>
+        <div class="mt-6 flex justify-end gap-2">
+          <Button variant="outline" onclick={() => (formulaToConfirm = null)}>Cancel</Button>
+          <Button
+            variant="secondary"
+            onclick={() => applyPasteFormulaData(formulaToConfirm!, false)}
+          >
+            Append
+          </Button>
+          <Button
+            variant="default"
+            onclick={() => applyPasteFormulaData(formulaToConfirm!, true)}
+            autofocus
+          >
             Replace
           </Button>
         </div>

--- a/src/lib/components/compound-editor-modal.svelte
+++ b/src/lib/components/compound-editor-modal.svelte
@@ -71,7 +71,7 @@
   let presetToConfirm = $state<CompoundPreset | null>(null);
 
   let isEmptyComposition = $derived(
-    formData.elements.length === 0 || (!compositionTouched && !compound && formData.name === ""),
+    formData.elements.length === 0 || (!compositionTouched && !compound),
   );
 
   // Picker and UI states
@@ -378,6 +378,11 @@
   }
 
   function handlePasteFormula(elements: ParsedElement[]) {
+    if (isEmptyComposition) {
+      formData.elements = [];
+      elementTexts = [];
+      if (mode === "weight") weightTexts = [];
+    }
     for (const elem of elements) {
       const existing = formData.elements.find((e) => e.atomicNumber === elem.atomicNumber);
       if (existing) {

--- a/src/lib/components/compound-editor-modal.svelte
+++ b/src/lib/components/compound-editor-modal.svelte
@@ -402,12 +402,12 @@
     formData.phase = preset.phase;
 
     const atomCounts = presetToAtomCounts(preset);
-    formData.elements = atomCounts.map(e => ({ ...e }));
-    elementTexts = atomCounts.map(e => getLocalSymbol(e.atomicNumber));
+    formData.elements = atomCounts.map((e) => ({ ...e }));
+    elementTexts = atomCounts.map((e) => getLocalSymbol(e.atomicNumber));
 
     if (preset.mode === "weight") {
-      weightTexts = atomCounts.map(e => {
-        const orig = preset.elements.find(x => x.atomicNumber === e.atomicNumber);
+      weightTexts = atomCounts.map((e) => {
+        const orig = preset.elements.find((x) => x.atomicNumber === e.atomicNumber);
         return orig ? String(orig.value) : "0";
       });
       mode = "weight";

--- a/src/lib/components/compound-editor-modal.svelte
+++ b/src/lib/components/compound-editor-modal.svelte
@@ -21,6 +21,9 @@
   import ElementPicker from "./element-picker.svelte";
   import FormulaFooter from "./compound-editor/formula-footer.svelte";
   import SumTracker from "./compound-editor/sum-tracker.svelte";
+  import QuickStartPanel from "./compound-editor/quick-start-panel.svelte";
+  import { presetToAtomCounts, type CompoundPreset } from "$lib/data/compound-presets";
+  import type { ParsedElement } from "$lib/utils/formula-parser";
 
   interface CompoundEditorFormData {
     name: string;
@@ -53,14 +56,23 @@
     density: "",
     iValue: "",
     phase: "condensed",
-    elements: [{ atomicNumber: 1, atomCount: 1 }],
+    elements: [
+      { atomicNumber: 3, atomCount: 1 },
+      { atomicNumber: 9, atomCount: 1 },
+    ],
   };
 
   let formData = $state<CompoundEditorFormData>({ ...initialData });
-  let elementTexts = $state<string[]>(["H"]);
-  let weightTexts = $state<string[]>(["100"]);
+  let elementTexts = $state<string[]>(["Li", "F"]);
+  let weightTexts = $state<string[]>(["26.76", "73.24"]);
   let mode = $state<"formula" | "weight">("formula");
   let showDeleteConfirm = $state(false);
+  let compositionTouched = $state(false);
+  let presetToConfirm = $state<CompoundPreset | null>(null);
+
+  let isEmptyComposition = $derived(
+    formData.elements.length === 0 || (!compositionTouched && !compound && formData.name === ""),
+  );
 
   // Picker and UI states
   let pickerMode = $state<"ADD" | "EDIT" | null>(null);
@@ -176,12 +188,14 @@
         mode = "formula";
         resetTransientState();
         sortElements();
+        compositionTouched = false;
       } else if (isOpen && !c) {
-        formData = { ...initialData };
-        elementTexts = ["H"];
-        weightTexts = ["100"];
+        formData = { ...initialData, elements: initialData.elements.map((e) => ({ ...e })) };
+        elementTexts = ["Li", "F"];
+        weightTexts = computeInitialWeightTexts(formData.elements);
         mode = "formula";
         resetTransientState();
+        compositionTouched = false;
       }
     });
   });
@@ -231,6 +245,7 @@
       }
     }
     mode = newMode;
+    compositionTouched = true;
   }
 
   function convertWeightFractionsToAtomCounts(): CompoundElementEntry[] | null {
@@ -264,6 +279,7 @@
   function handleRescale() {
     const values = weightTexts.map((t) => parseFloat(t) || 0);
     weightTexts = rescaleTo100(values).map((v) => v.toFixed(2));
+    compositionTouched = true;
   }
 
   function handleRemoveElement(index: number) {
@@ -273,10 +289,12 @@
       weightTexts.splice(index, 1);
       confirmRemoveIndex = null;
       editDuplicatePrompt = null;
+      compositionTouched = true;
     }
   }
 
   function handleAtomCountChange(index: number, count: string) {
+    compositionTouched = true;
     const num = parseFloat(count);
     const element = formData.elements[index];
     if (!isNaN(num) && num > 0 && element) {
@@ -303,6 +321,7 @@
           element.atomicNumber = z;
           elementTexts[pickerEditIndex] = getLocalSymbol(z);
           sortElements();
+          compositionTouched = true;
         }
       }
       pickerMode = null;
@@ -325,6 +344,7 @@
     elementTexts.splice(duplicateIndex, 1);
     weightTexts.splice(duplicateIndex, 1);
     sortElements();
+    compositionTouched = true;
   }
 
   function handleRemoveDuplicateBanner() {
@@ -354,6 +374,59 @@
 
     editDuplicatePrompt = null;
     sortElements();
+    compositionTouched = true;
+  }
+
+  function handlePasteFormula(elements: ParsedElement[]) {
+    for (const elem of elements) {
+      const existing = formData.elements.find((e) => e.atomicNumber === elem.atomicNumber);
+      if (existing) {
+        existing.atomCount += elem.atomCount;
+      } else {
+        formData.elements.push({ atomicNumber: elem.atomicNumber, atomCount: elem.atomCount });
+        elementTexts.push(getLocalSymbol(elem.atomicNumber));
+        if (mode === "weight") weightTexts.push("0");
+      }
+    }
+    sortElements();
+    if (mode === "weight") {
+      weightTexts = computeInitialWeightTexts(formData.elements);
+    }
+    compositionTouched = true;
+  }
+
+  function applyPresetData(preset: CompoundPreset) {
+    formData.name = preset.name;
+    formData.density = String(preset.density);
+    formData.iValue = preset.iValue ? String(preset.iValue) : "";
+    formData.phase = preset.phase;
+
+    const atomCounts = presetToAtomCounts(preset);
+    formData.elements = atomCounts.map(e => ({ ...e }));
+    elementTexts = atomCounts.map(e => getLocalSymbol(e.atomicNumber));
+
+    if (preset.mode === "weight") {
+      weightTexts = atomCounts.map(e => {
+        const orig = preset.elements.find(x => x.atomicNumber === e.atomicNumber);
+        return orig ? String(orig.value) : "0";
+      });
+      mode = "weight";
+    } else {
+      weightTexts = computeInitialWeightTexts(formData.elements);
+      mode = "formula";
+    }
+
+    sortElements();
+    compositionTouched = true;
+    presetToConfirm = null;
+  }
+
+  function handleApplyPreset(preset: CompoundPreset) {
+    if (formData.elements.length === 0 || (!compositionTouched && !compound)) {
+      applyPresetData(preset);
+    } else {
+      presetToConfirm = preset;
+    }
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -496,6 +569,11 @@
             </div>
 
             <div class="grid gap-2">
+              <QuickStartPanel
+                isEmpty={isEmptyComposition}
+                onPasteFormula={handlePasteFormula}
+                onApplyPreset={handleApplyPreset}
+              />
               <div class="flex items-center justify-between">
                 <Label>Elements</Label>
                 <div role="tablist" class="flex gap-2">
@@ -675,6 +753,7 @@
                             step="0.01"
                             placeholder="Weight %"
                             bind:value={weightTexts[index]}
+                            oninput={() => (compositionTouched = true)}
                             class="w-32 sm:w-48 text-right hide-spin-button"
                             aria-label={`Weight fraction % for element ${index + 1}`}
                           />
@@ -864,6 +943,35 @@
     </Dialog.Content>
   </Dialog.Portal>
 </Dialog.Root>
+
+{#if presetToConfirm}
+  <Dialog.Root
+    open={!!presetToConfirm}
+    onOpenChange={(o) => {
+      if (!o) presetToConfirm = null;
+    }}
+  >
+    <Dialog.Portal>
+      <Dialog.Overlay class="fixed inset-0 z-[60] bg-black/80" />
+      <Dialog.Content
+        class="fixed left-[50%] top-[50%] z-[60] w-full max-w-sm translate-x-[-50%] translate-y-[-50%] rounded-md border bg-background p-6 shadow-lg"
+      >
+        <Dialog.Title class="text-lg font-semibold">Replace Composition</Dialog.Title>
+        <p class="mt-2 text-sm text-muted-foreground">
+          Replace your current composition with {presetToConfirm.name}?
+        </p>
+        <div class="mt-6 flex justify-end gap-2">
+          <Button variant="outline" onclick={() => (presetToConfirm = null)} autofocus>
+            Cancel
+          </Button>
+          <Button variant="default" onclick={() => applyPresetData(presetToConfirm!)}>
+            Replace
+          </Button>
+        </div>
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+{/if}
 
 <style>
   :global(.hide-spin-button::-webkit-inner-spin-button),

--- a/src/lib/components/compound-editor/quick-start-panel.svelte
+++ b/src/lib/components/compound-editor/quick-start-panel.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import { Input } from "$lib/components/ui/input";
+  import { Button } from "$lib/components/ui/button";
+  import { COMPOUND_PRESETS, type CompoundPreset } from "$lib/data/compound-presets";
+  import { parseFormula, type ParsedElement } from "$lib/utils/formula-parser";
+  import { getElementSymbol } from "$lib/utils/element-data";
+  import { cn } from "$lib/utils.js";
+
+  interface Props {
+    isEmpty: boolean;
+    onPasteFormula: (elements: ParsedElement[]) => void;
+    onApplyPreset: (preset: CompoundPreset) => void;
+  }
+
+  let { isEmpty, onPasteFormula, onApplyPreset }: Props = $props();
+
+  let formulaInput = $state("");
+  let isExpanded = $state(true);
+
+  // When isEmpty becomes true, automatically expand.
+  $effect(() => {
+    if (isEmpty) {
+      isExpanded = true;
+    } else {
+      isExpanded = false;
+    }
+  });
+
+  let parsed = $derived(
+    formulaInput.trim() ? parseFormula(formulaInput) : { elements: undefined, error: undefined },
+  );
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (parsed.elements) {
+        onPasteFormula(parsed.elements);
+        formulaInput = "";
+      }
+    }
+  }
+
+  function formatParsed(elements: ParsedElement[]) {
+    return elements
+      .map((e) => `${e.atomCount} ${getElementSymbol(e.atomicNumber) || `Z=${e.atomicNumber}`}`)
+      .join(" · ");
+  }
+</script>
+
+{#if isExpanded}
+  <div
+    class="mb-6 overflow-hidden rounded-[10px] border border-[#ffd9c7] bg-gradient-to-b from-[#fff5f0] to-white dark:from-accent/10 dark:to-background shadow-sm"
+    data-testid="quick-start-panel"
+  >
+    <div class="p-4">
+      <h3 class="mb-3 text-sm font-semibold text-foreground flex items-center gap-2">
+        <span class="text-xl leading-none">🚀</span> Quick Start
+      </h3>
+      <div class="grid gap-6 md:grid-cols-2">
+        <!-- Card 1: Paste formula -->
+        <div class="flex flex-col gap-2 rounded-lg border bg-card/50 p-3 shadow-sm">
+          <label for="qs-formula" class="text-xs font-medium text-muted-foreground"
+            >Paste a formula</label
+          >
+          <Input
+            id="qs-formula"
+            bind:value={formulaInput}
+            onkeydown={handleKeyDown}
+            placeholder="e.g., C6H12O6"
+            class={cn(
+              "bg-background",
+              parsed.error && formulaInput.trim() ? "border-destructive" : "",
+            )}
+          />
+          <div class="min-h-[20px]">
+            {#if formulaInput.trim()}
+              {#if parsed.error}
+                <p class="text-xs text-destructive">{parsed.error}</p>
+              {:else if parsed.elements}
+                <p class="text-xs text-muted-foreground">
+                  → {formatParsed(parsed.elements)}
+                  <span class="ml-1 text-[10px] opacity-70">(press Enter to apply)</span>
+                </p>
+              {/if}
+            {/if}
+          </div>
+        </div>
+
+        <!-- Card 2: Presets -->
+        <div class="flex flex-col gap-2 rounded-lg border bg-card/50 p-3 shadow-sm">
+          <span class="text-xs font-medium text-muted-foreground">Start from preset</span>
+          <div class="flex flex-wrap gap-2">
+            {#each COMPOUND_PRESETS as preset}
+              <Button
+                variant="secondary"
+                size="sm"
+                class="h-7 text-xs rounded-full bg-background border hover:bg-accent hover:text-accent-foreground"
+                onclick={() => onApplyPreset(preset)}
+                data-testid={`preset-btn-${preset.shortName}`}
+              >
+                {preset.shortName}
+              </Button>
+            {/each}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{:else}
+  <!-- Collapsed state -->
+  <div
+    class="mb-4 flex items-center justify-center gap-2 text-sm text-muted-foreground"
+    data-testid="quick-start-collapsed"
+  >
+    <button
+      type="button"
+      class="hover:text-foreground hover:underline"
+      onclick={() => (isExpanded = true)}
+    >
+      Paste formula…
+    </button>
+    <span>·</span>
+    <button
+      type="button"
+      class="hover:text-foreground hover:underline"
+      onclick={() => (isExpanded = true)}
+    >
+      Presets ▾
+    </button>
+  </div>
+{/if}

--- a/src/lib/components/compound-editor/quick-start-panel.svelte
+++ b/src/lib/components/compound-editor/quick-start-panel.svelte
@@ -90,7 +90,7 @@
         <div class="flex flex-col gap-2 rounded-lg border bg-card/50 p-3 shadow-sm">
           <span class="text-xs font-medium text-muted-foreground">Start from preset</span>
           <div class="flex flex-wrap gap-2">
-            {#each COMPOUND_PRESETS as preset}
+            {#each COMPOUND_PRESETS as preset (preset.shortName)}
               <Button
                 variant="secondary"
                 size="sm"

--- a/src/lib/data/compound-presets.ts
+++ b/src/lib/data/compound-presets.ts
@@ -1,0 +1,132 @@
+import type { CompoundElementEntry } from "$lib/state/custom-compounds.svelte";
+import { computeAtomCounts, normalizeAtomCounts } from "$lib/utils/element-data";
+
+export interface CompoundPreset {
+  name: string;
+  shortName: string;
+  density: number;
+  iValue?: number;
+  phase: "gas" | "condensed";
+  mode: "formula" | "weight";
+  // If mode === "formula", value is atom count.
+  // If mode === "weight", value is weight percentage (e.g., 10.13 for 10.13%).
+  elements: { atomicNumber: number; value: number }[];
+}
+
+export const COMPOUND_PRESETS: CompoundPreset[] = [
+  {
+    name: "Water",
+    shortName: "Water",
+    density: 1.0,
+    iValue: 75.0,
+    phase: "condensed",
+    mode: "formula",
+    elements: [
+      { atomicNumber: 1, value: 2 },
+      { atomicNumber: 8, value: 1 },
+    ],
+  },
+  {
+    name: "A-150 tissue-equivalent plastic",
+    shortName: "A-150",
+    density: 1.127,
+    iValue: 65.1,
+    phase: "condensed",
+    mode: "weight",
+    elements: [
+      { atomicNumber: 1, value: 10.13 },
+      { atomicNumber: 6, value: 77.55 },
+      { atomicNumber: 7, value: 3.51 },
+      { atomicNumber: 8, value: 5.23 },
+      { atomicNumber: 9, value: 1.74 },
+      { atomicNumber: 20, value: 1.84 },
+    ],
+  },
+  {
+    name: "ICRU compact bone",
+    shortName: "Bone",
+    density: 1.85,
+    iValue: 91.9,
+    phase: "condensed",
+    mode: "weight",
+    elements: [
+      { atomicNumber: 1, value: 6.4 },
+      { atomicNumber: 6, value: 27.8 },
+      { atomicNumber: 7, value: 2.7 },
+      { atomicNumber: 8, value: 41.0 },
+      { atomicNumber: 12, value: 0.2 },
+      { atomicNumber: 15, value: 7.0 },
+      { atomicNumber: 16, value: 0.2 },
+      { atomicNumber: 20, value: 14.7 },
+    ],
+  },
+  {
+    name: "ICRU striated muscle",
+    shortName: "Muscle",
+    density: 1.04,
+    iValue: 74.7,
+    phase: "condensed",
+    mode: "weight",
+    elements: [
+      { atomicNumber: 1, value: 10.2 },
+      { atomicNumber: 6, value: 12.3 },
+      { atomicNumber: 7, value: 3.5 },
+      { atomicNumber: 8, value: 72.9 },
+      { atomicNumber: 11, value: 0.08 },
+      { atomicNumber: 12, value: 0.02 },
+      { atomicNumber: 15, value: 0.2 },
+      { atomicNumber: 16, value: 0.5 },
+      { atomicNumber: 19, value: 0.3 },
+      { atomicNumber: 20, value: 0.007 },
+    ],
+  },
+  {
+    name: "ICRU lung",
+    shortName: "Lung",
+    density: 0.296,
+    iValue: 75.3,
+    phase: "condensed",
+    mode: "weight",
+    elements: [
+      { atomicNumber: 1, value: 10.3 },
+      { atomicNumber: 6, value: 10.5 },
+      { atomicNumber: 7, value: 3.1 },
+      { atomicNumber: 8, value: 74.9 },
+      { atomicNumber: 11, value: 0.2 },
+      { atomicNumber: 15, value: 0.2 },
+      { atomicNumber: 16, value: 0.3 },
+      { atomicNumber: 17, value: 0.3 },
+      { atomicNumber: 19, value: 0.2 },
+    ],
+  },
+  {
+    name: "Air (dry)",
+    shortName: "Air",
+    density: 1.205e-3,
+    iValue: 85.7,
+    phase: "gas",
+    mode: "weight",
+    elements: [
+      { atomicNumber: 7, value: 75.5 },
+      { atomicNumber: 8, value: 23.2 },
+      { atomicNumber: 18, value: 1.3 },
+    ],
+  },
+];
+
+export function presetToAtomCounts(preset: CompoundPreset): CompoundElementEntry[] {
+  if (preset.mode === "formula") {
+    return preset.elements.map((e) => ({ atomicNumber: e.atomicNumber, atomCount: e.value }));
+  } else {
+    // Convert weight percentages to atom counts
+    const wfs = preset.elements.map((e) => ({
+      atomicNumber: e.atomicNumber,
+      weightFraction: e.value / 100,
+    }));
+    const atomCounts = computeAtomCounts(wfs);
+    if (!atomCounts) {
+      throw new Error(`Failed to compute atom counts for preset: ${preset.name}`);
+    }
+    return normalizeAtomCounts(atomCounts);
+  }
+}

--- a/src/tests/components/compound-editor-modal.test.ts
+++ b/src/tests/components/compound-editor-modal.test.ts
@@ -39,6 +39,13 @@ async function addElement(symbol: string) {
   await fireEvent.keyDown(addInput, { key: "Enter" });
 }
 
+async function removeRow(index: number) {
+  const removeBtns = screen.getAllByTestId("picker-element-row-remove");
+  await fireEvent.click(removeBtns[index]!);
+  const confirmBtn = screen.getByRole("button", { name: "Yes, remove" });
+  await fireEvent.click(confirmBtn);
+}
+
 describe("CompoundEditorModal — Save gating & derived UI", () => {
   async function flushDialog() {
     cleanup();
@@ -65,8 +72,8 @@ describe("CompoundEditorModal — Save gating & derived UI", () => {
     await fireEvent.input(nameInput(), { target: { value: "Duplicate" } });
     await fireEvent.input(densityInput(), { target: { value: "1.0" } });
 
-    // H is present by default; add a second H.
-    await addElement("H");
+    // Li is present by default; add a second Li.
+    await addElement("Li");
 
     // The duplicate banner is shown AND Save is disabled — the exact behaviour
     // PR #653 regressed (banner showed but Save stayed enabled).
@@ -94,12 +101,17 @@ describe("CompoundEditorModal — Save gating & derived UI", () => {
     await fireEvent.input(nameInput(), { target: { value: "Water" } });
     await fireEvent.input(densityInput(), { target: { value: "1.0" } });
 
-    // H present; set count 2, add O count 1 → H2O.
-    const counts = screen.getAllByPlaceholderText(/count/i);
-    await fireEvent.input(counts[0]!, { target: { value: "2" } });
+    // Initially Li (3) and F (9). Add H (1) and O (8).
+    await addElement("H");
     await addElement("O");
-    const countsAfter = screen.getAllByPlaceholderText(/count/i);
-    await fireEvent.input(countsAfter[1]!, { target: { value: "1" } });
+    // Sorted order is now: H (1), Li (3), O (8), F (9)
+    await removeRow(3); // Removes F
+    await removeRow(1); // Removes Li
+
+    // Now H and O are present.
+    const counts = screen.getAllByPlaceholderText(/count/i);
+    await fireEvent.input(counts[0]!, { target: { value: "2" } }); // H
+    await fireEvent.input(counts[1]!, { target: { value: "1" } }); // O
 
     expect(screen.getByTestId("compound-formula-string")).toHaveTextContent("H₂O");
     expect(screen.getByTestId("compound-total-atoms")).toHaveTextContent("3 atoms");

--- a/tests/e2e/custom-compounds.spec.ts
+++ b/tests/e2e/custom-compounds.spec.ts
@@ -141,14 +141,13 @@ test.describe("Custom Compounds — Editor Modal", () => {
     const densityInput = page.getByRole("spinbutton", { name: /density/i });
     await densityInput.fill("1.0");
 
-    // First H
-    // H is present by default
+    // Li is present by default
     const atomCount = page.getByPlaceholder(/count/i).first();
     await atomCount.fill("2");
 
-    // Add another H (duplicate)
+    // Add another Li (duplicate)
     const addInput = page.getByPlaceholder(/Type symbol or element/i);
-    await addInput.fill("H");
+    await addInput.fill("Li");
     await addInput.press("Enter");
     const atomCount2 = page.getByPlaceholder(/count/i).nth(1);
     await atomCount2.fill("1");
@@ -172,21 +171,20 @@ test.describe("Custom Compounds — Editor Modal", () => {
 
     // Fill form
     const nameInput = page.getByRole("textbox", { name: /name/i });
-    await nameInput.fill("LiF Pellet");
+    await nameInput.fill("BeO Pellet");
 
     const densityInput = page.getByRole("spinbutton", { name: /density/i });
-    await densityInput.fill("2.20");
+    await densityInput.fill("3.01");
 
-    // Li (Z=3) - element resolves automatically on input
-    await page.getByTestId("picker-element-tile-1").first().click();
-    await page.getByTestId("picker-grid-tile-3").first().click();
+    // Change Li (Z=3) to Be (Z=4)
+    await page.getByTestId("picker-element-tile-3").first().click();
+    await page.getByTestId("picker-grid-tile-4").first().click();
     const atomCount = page.getByPlaceholder(/count/i).first();
     await atomCount.fill("1");
 
-    // Add F (Z=9)
-    const addInput = page.getByPlaceholder(/Type symbol or element/i);
-    await addInput.fill("F");
-    await addInput.press("Enter");
+    // Change F (Z=9) to O (Z=8)
+    await page.getByTestId("picker-element-tile-9").first().click();
+    await page.getByTestId("picker-grid-tile-8").first().click();
     const atomCount2 = page.getByPlaceholder(/count/i).nth(1);
     await atomCount2.fill("1");
 
@@ -209,15 +207,15 @@ test.describe("Custom Compounds — Editor Modal", () => {
     const customList = page.getByTestId("picker-material-list-custom");
     await expect(customList).toBeVisible();
 
-    // Verify LiF Pellet is visible in the custom list.
-    await expect(customList.getByText(/LiF Pellet/i)).toBeVisible();
+    // Verify BeO Pellet is visible in the custom list.
+    await expect(customList.getByText(/BeO Pellet/i)).toBeVisible();
 
     // Verify density description is visible on the custom compound row.
     await expect(
       customList
-        .locator('[data-testid^="picker-material-item-"]', { hasText: /LiF Pellet/i })
+        .locator('[data-testid^="picker-material-item-"]', { hasText: /BeO Pellet/i })
         .first(),
-    ).toContainText(/2\.20\d* g\/cm/);
+    ).toContainText(/3\.01\d* g\/cm/);
   });
 
   test("AC-6: Delete compound confirmation", async ({ page }) => {
@@ -317,19 +315,19 @@ test.describe("Custom Compounds — Editor Modal", () => {
     await expect(carbonEditBtn).toBeVisible();
     await expect(page.getByText(/Z=6/i).first()).toBeVisible();
 
-    // Edit the first element (H)
-    const hydrogenEditBtn = page.getByTestId("picker-element-tile-1").first();
-    await hydrogenEditBtn.click();
+    // Edit the first element (Li)
+    const lithiumEditBtn = page.getByTestId("picker-element-tile-3").first();
+    await lithiumEditBtn.click();
 
     // The picker should appear for editing
     await expect(pickerGrid).toBeVisible();
 
-    // Change H to O (Z=8)
+    // Change Li to O (Z=8)
     const oxygenTile = page.getByTestId("picker-grid-tile-8").first(); // the one in the picker
     await oxygenTile.click();
 
-    // Verify H is gone and O is present
-    await expect(page.getByTestId("picker-element-tile-1")).not.toBeVisible();
+    // Verify Li is gone and O is present
+    await expect(page.getByTestId("picker-element-tile-3")).not.toBeVisible();
     const oxygenEditBtn = page.getByTestId("picker-element-tile-8").first();
     await expect(oxygenEditBtn).toBeVisible();
   });
@@ -462,15 +460,10 @@ test.describe("Custom Compounds — Program Compatibility Filter", () => {
     await densityInput.fill("2.20");
 
     // Li
-    await page.getByTestId("picker-element-tile-1").first().click();
-    await page.getByTestId("picker-grid-tile-3").first().click();
     const atomCount = page.getByPlaceholder(/count/i).first();
     await atomCount.fill("1");
 
     // F
-    const addInput = page.getByPlaceholder(/Type symbol or element/i);
-    await addInput.fill("F");
-    await addInput.press("Enter");
     const atomCount2 = page.getByPlaceholder(/count/i).nth(1);
     await atomCount2.fill("1");
 
@@ -585,9 +578,17 @@ test.describe("Scenario 2: Water (H2O) — formula mode and stopping power sanit
     await page.getByRole("textbox", { name: /name/i }).fill("Water H2O formula");
     await page.getByRole("spinbutton", { name: /density/i }).fill("1.0");
 
+    // Change Li to H
+    await page.getByTestId("picker-element-tile-3").first().click();
+    await page.getByTestId("picker-grid-tile-1").first().click();
+
+    // Remove F
+    const removeBtn = page.getByTestId("picker-element-row-remove").nth(1);
+    await removeBtn.click();
+    const confirmBtn = page.getByRole("button", { name: "Yes, remove" });
+    await confirmBtn.click();
+
     // First element: H with atom count 2
-    // H is present by default
-    // await el0.blur();
     const count0 = page.getByPlaceholder(/count/i).first();
     await count0.fill("2");
 
@@ -655,8 +656,15 @@ test.describe("Scenario 2: Water (H2O) — formula mode and stopping power sanit
     await page.getByRole("textbox", { name: /name/i }).fill("Water H2O weight");
     await page.getByRole("spinbutton", { name: /density/i }).fill("1.0");
 
-    // First element: H with a placeholder atom count (will be replaced by weight mode)
-    // H is present by default
+    // Change Li to H
+    await page.getByTestId("picker-element-tile-3").first().click();
+    await page.getByTestId("picker-grid-tile-1").first().click();
+
+    // Remove F
+    const removeBtn = page.getByTestId("picker-element-row-remove").nth(1);
+    await removeBtn.click();
+    const confirmBtn = page.getByRole("button", { name: "Yes, remove" });
+    await confirmBtn.click();
 
     // Switch to weight fraction mode
     const weightTab = page.getByRole("tab", { name: /weight fraction/i });
@@ -776,16 +784,10 @@ test.describe("Scenario 1: LiF pellet smoke test", () => {
     const densityInput = page.getByRole("spinbutton", { name: /density/i });
     await densityInput.fill("2.20");
 
-    // Li (Z=3)
-    await page.getByTestId("picker-element-tile-1").first().click();
-    await page.getByTestId("picker-grid-tile-3").first().click();
+    // Li and F are present by default
     const atomCount = page.getByPlaceholder(/count/i).first();
     await atomCount.fill("1");
 
-    // F (Z=9)
-    const addInput = page.getByPlaceholder(/Type symbol or element/i);
-    await addInput.fill("F");
-    await addInput.press("Enter");
     const atomCount2 = page.getByPlaceholder(/count/i).nth(1);
     await atomCount2.fill("1");
 
@@ -842,6 +844,16 @@ test.describe("Custom Compounds — Live Derived UI (Issue #645)", () => {
 
     // Build H52 C63 N3 O25 — rows sort ascending Z → H, C, N, O.
     const addInput = page.getByPlaceholder(/Type symbol or element/i);
+    await addInput.fill("H");
+    await addInput.press("Enter");
+    
+    // Now we have H (1), Li (3), F (9). Remove F, then Li.
+    const removeBtns = page.getByTestId("picker-element-row-remove");
+    await removeBtns.nth(2).click(); // Remove F
+    await page.getByRole("button", { name: "Yes, remove" }).click();
+    await removeBtns.nth(1).click(); // Remove Li
+    await page.getByRole("button", { name: "Yes, remove" }).click();
+
     for (const sym of ["C", "N", "O"]) {
       await addInput.fill(sym);
       await addInput.press("Enter");

--- a/tests/e2e/custom-compounds.spec.ts
+++ b/tests/e2e/custom-compounds.spec.ts
@@ -846,7 +846,7 @@ test.describe("Custom Compounds — Live Derived UI (Issue #645)", () => {
     const addInput = page.getByPlaceholder(/Type symbol or element/i);
     await addInput.fill("H");
     await addInput.press("Enter");
-    
+
     // Now we have H (1), Li (3), F (9). Remove F, then Li.
     const removeBtns = page.getByTestId("picker-element-row-remove");
     await removeBtns.nth(2).click(); // Remove F


### PR DESCRIPTION
Resolves #646

## Changes
- Changed the default elements for a new compound from a single Hydrogen atom to Lithium and Fluorine (LiF), addressing the "empty state" experience.
- Implemented the `QuickStartPanel` within the compound editor modal, introducing predefined presets (Water, A-150, Bone, Muscle, Lung, Air).
- Added a parser to handle pasting formulas (e.g. `H2O`, `C6H12O6`) directly into the panel, which automatically adds the respective elements and updates their counts.
- Re-aligned end-to-end tests in `custom-compounds.spec.ts` to expect the new LiF initial state rather than H.

## Note
There is a pre-existing unrelated accessibility violation for the PDF and CSV export buttons (`tests/e2e/accessibility.spec.ts`) regarding color contrast that failed during CI, but it remains out of scope for this ticket.
