### PR TITLE
docs: split build+e2e code block into two for easier copy-paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Playwright serves the built app with `pnpm preview`, so the safe local flow is:
 
 ```sh
 pnpm build
+```
+
+```sh
 pnpm test:e2e
 ```
 


### PR DESCRIPTION
Splits the single `pnpm build && pnpm test:e2e` code block in the README into two separate blocks so each command can be copy-pasted individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013CJtf7sDjJFzXBr5cKotSu)_