### PR TITLE
docs: update Team section to distinguish v1 and v2 authorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,6 @@ To maintain a secure and clean codebase, follow these rules when managing depend
 
 ### Team
 
-Developed by [Piotr Połeć](https://github.com/piotrpolec) and [Marek Ślązak](https://github.com/Mexolius) under supervision of [Leszek Grzanka](https://github.com/grzanka)
+v1 was developed by [Piotr Połeć](https://github.com/piotrpolec) and [Marek Ślązak](https://github.com/Mexolius) under supervision of [Leszek Grzanka](https://github.com/grzanka).
+
+v2 is led by [Leszek Grzanka](https://github.com/grzanka) with AI assistants (GitHub Copilot, Claude Code, opencode).


### PR DESCRIPTION
Splits the single "Team" sentence into two, making the v1/v2 distinction explicit:

**Before:**
> Developed by Piotr Połeć and Marek Ślązak under supervision of Leszek Grzanka

**After:**
> v1 was developed by Piotr Połeć and Marek Ślązak under supervision of Leszek Grzanka.
>
> v2 is led by Leszek Grzanka with AI assistants (GitHub Copilot, Claude Code, opencode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013CJtf7sDjJFzXBr5cKotSu)_